### PR TITLE
refactor: remove QEMU-specific fields from container.Config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,6 @@ require (
 	go.opentelemetry.io/otel/exporters/stdout/stdouttrace v1.39.0
 	go.opentelemetry.io/otel/sdk v1.39.0
 	go.yaml.in/yaml/v2 v2.4.3
-	golang.org/x/crypto v0.46.0
 	golang.org/x/exp v0.0.0-20250911091902-df9299821621
 	golang.org/x/sync v0.19.0
 	golang.org/x/sys v0.39.0
@@ -94,6 +93,7 @@ require (
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
+	golang.org/x/crypto v0.46.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	k8s.io/klog/v2 v2.130.1 // indirect
 )

--- a/pkg/container/config.go
+++ b/pkg/container/config.go
@@ -15,11 +15,7 @@
 package container
 
 import (
-	"crypto/ed25519"
-	"time"
-
 	apko_types "chainguard.dev/apko/pkg/build/types"
-	"golang.org/x/crypto/ssh"
 )
 
 const (
@@ -42,33 +38,21 @@ type Capabilities struct {
 	Drop       []string // List of kernel capabilities to drop from the container.
 }
 
+// Config holds the configuration for a container runner.
 type Config struct {
-	PackageName              string
-	Mounts                   []BindMount
-	Capabilities             Capabilities
-	Environment              map[string]string
-	ImgRef                   string
-	PodID                    string
-	Arch                     apko_types.Architecture
-	RunAsUID                 string
-	RunAs                    string
-	WorkspaceDir             string
-	CacheDir                 string
-	CPU, CPUModel, Memory    string
-	SSHKey                   ssh.Signer
-	SSHAddress               string             // SSH address for the build / chrooted environment
-	SSHControlAddress        string             // SSH address for the control / management environment
-	SSHHostKey               string             // Path to known_hosts file containing the VM's host key
-	VMHostKeySigner          ssh.Signer         // VM's SSH host key (private signer)
-	VMHostKeyPublic          ssh.PublicKey      // VM's SSH host key (public) - for verification
-	VMHostKeyPrivateKeyBytes []byte             // VM's SSH host key (raw private key bytes) - for injection
-	VMHostKeyPrivate         ed25519.PrivateKey // VM's SSH host key (raw private key) - for explicit zeroing
-	InitramfsPath            string             // Path to temp initramfs file (contains sensitive key material)
-	Disk                     string
-	Timeout                  time.Duration
-	SSHBuildClient           *ssh.Client // SSH client for the build environment, may not have privileges
-	SSHControlBuildClient    *ssh.Client // SSH client for control operations in the build environment, has privileges
-	SSHControlClient         *ssh.Client // SSH client for unrestricted control environment, has privileges
-	QemuPID                  int
-	RunAsGID                 string
+	PackageName  string
+	Mounts       []BindMount
+	Capabilities Capabilities
+	Environment  map[string]string
+	ImgRef       string
+	PodID        string
+	Arch         apko_types.Architecture
+	RunAsUID     string
+	WorkspaceDir string
+	CacheDir     string
+
+	// Resource configuration (currently informational, may be used by future runners)
+	CPU      string
+	CPUModel string
+	Memory   string
 }


### PR DESCRIPTION
## Summary

Remove fields from `container.Config` that were only used by the removed QEMU runner.

### Removed Fields

**SSH-related (QEMU VM communication):**
- `SSHKey`, `SSHAddress`, `SSHControlAddress`, `SSHHostKey`
- `SSHBuildClient`, `SSHControlBuildClient`, `SSHControlClient`

**VM host key fields:**
- `VMHostKeySigner`, `VMHostKeyPublic`, `VMHostKeyPrivateKeyBytes`, `VMHostKeyPrivate`

**Other QEMU-specific:**
- `QemuPID`, `InitramfsPath`, `Disk`, `Timeout`

**Unused by Docker runner:**
- `RunAs` (Docker only uses `RunAsUID`)
- `RunAsGID`

### Also Removed

- `runAs()` and `runAsGID()` helper functions from `test.go`
- Unused `math` import

### Result

- `container.Config` reduced from 30 fields to 13 fields
- Removed `golang.org/x/crypto/ssh` and `crypto/ed25519` imports from config.go
- **-68 net lines**

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] `go vet ./...` passes
- [x] `go mod tidy` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)