### PR TITLE
refactor: simplify container.Runner interface

### DIFF
--- a/pkg/container/docker/docker_runner.go
+++ b/pkg/container/docker/docker_runner.go
@@ -15,8 +15,6 @@
 package docker
 
 import (
-	"bufio"
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -357,70 +355,6 @@ func (dk *docker) Debug(ctx context.Context, cfg *mcontainer.Config, envOverride
 	default:
 		return fmt.Errorf("task exited with code %d", inspectResp.ExitCode)
 	}
-}
-
-// WorkspaceTar implements Runner
-// This is a noop for Docker, which uses bind-mounts to manage the workspace
-func (dk *docker) WorkspaceTar(ctx context.Context, cfg *mcontainer.Config, extraFiles []string) (io.ReadCloser, error) {
-	return nil, nil
-}
-
-// GetReleaseData returns the OS information (os-release contents) for the Docker runner.
-func (dk *docker) GetReleaseData(ctx context.Context, cfg *mcontainer.Config) (*apko_build.ReleaseData, error) {
-	if cfg.PodID == "" {
-		return nil, fmt.Errorf("pod not running")
-	}
-
-	taskIDResp, err := dk.cli.ContainerExecCreate(ctx, cfg.PodID, container.ExecOptions{
-		User:         cfg.RunAsUID,
-		Cmd:          []string{"cat", "/etc/os-release"},
-		WorkingDir:   runnerWorkdir,
-		Tty:          false,
-		AttachStderr: true,
-		AttachStdout: true,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to create exec task to read os-release: %w", err)
-	}
-
-	attachResp, err := dk.cli.ContainerExecAttach(ctx, taskIDResp.ID, container.ExecStartOptions{
-		Tty: false,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to attach to exec task: %w", err)
-	}
-	defer attachResp.Close()
-
-	var buf bytes.Buffer
-	bufWriter := bufio.NewWriter(&buf)
-	defer bufWriter.Flush()
-
-	log := clog.FromContext(ctx)
-	stderr := logwriter.New(log.Warn)
-	defer stderr.Close()
-
-	_, err = stdcopy.StdCopy(bufWriter, stderr, attachResp.Reader)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read os-release output: %w", err)
-	}
-
-	// Flush the buffer to ensure all data is written
-	err = bufWriter.Flush()
-	if err != nil {
-		return nil, fmt.Errorf("failed to flush buffer: %w", err)
-	}
-
-	inspectResp, err := dk.cli.ContainerExecInspect(ctx, taskIDResp.ID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get exit code from os-release task: %w", err)
-	}
-
-	if inspectResp.ExitCode != 0 {
-		return nil, fmt.Errorf("os-release task exited with code %d", inspectResp.ExitCode)
-	}
-
-	// Parse the os-release contents
-	return apko_build.ParseReleaseData(&buf)
 }
 
 type dockerLoader struct {

--- a/pkg/container/runner.go
+++ b/pkg/container/runner.go
@@ -16,38 +16,35 @@ package container
 
 import (
 	"context"
-	"io"
 
 	apko_build "chainguard.dev/apko/pkg/build"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 )
 
+// Debugger is an optional interface that runners can implement to support
+// interactive debugging sessions.
 type Debugger interface {
 	Debug(ctx context.Context, cfg *Config, envOverride map[string]string, cmd ...string) error
 }
 
+// Runner defines the interface for container runners used by the test command.
+// The build command uses BuildKit instead.
 type Runner interface {
 	Close() error
 	Name() string
 	TestUsability(ctx context.Context) bool
-	// OCIImageLoader returns a Loader that will load an OCI image from a stream.
-	// It should return the Loader, which will be used to load the provided image
-	// as a tar stream into the Loader. That image will be used as the root when StartPod() the container.
+	// OCIImageLoader returns a Loader that will load an OCI image.
+	// The image will be used as the root filesystem when StartPod() creates the container.
 	OCIImageLoader() Loader
 	StartPod(ctx context.Context, cfg *Config) error
 	Run(ctx context.Context, cfg *Config, envOverride map[string]string, cmd ...string) error
 	TerminatePod(ctx context.Context, cfg *Config) error
-	// TempDir returns the base for temporary directory, or "" if whatever is provided by the system is fine
+	// TempDir returns the base for temporary directory, or "" if the system default is fine.
 	TempDir() string
-	// WorkspaceTar returns an io.ReadCloser that can be used to read the status of the workspace.
-	// The io.ReadCloser itself is a tar stream, which can be written to an io.Writer as is,
-	// or passed to an fs.FS processor
-	WorkspaceTar(ctx context.Context, cfg *Config, extraFiles []string) (io.ReadCloser, error)
-	// GetReleaseData returns the release data for the container's OS (os-release)
-	GetReleaseData(ctx context.Context, cfg *Config) (*apko_build.ReleaseData, error)
 }
 
+// Loader handles loading OCI images into the container runtime.
 type Loader interface {
 	LoadImage(ctx context.Context, layer v1.Layer, arch apko_types.Architecture, bc *apko_build.Context) (ref string, err error)
 	RemoveImage(ctx context.Context, ref string) error


### PR DESCRIPTION
## Summary

Remove unused methods from the `container.Runner` interface:

| Method | Status | Reason |
|--------|--------|--------|
| `WorkspaceTar()` | Removed | Never called anywhere in codebase |
| `GetReleaseData()` | Removed | Never called anywhere in codebase |

### Changes

- Simplified `Runner` interface from 10 methods to 8 methods
- Removed ~60 lines of unused implementation from Docker runner
- Cleaned up unused imports (`bufio`, `bytes`, `io`)
- Added documentation comments to interfaces

### Interface After

```go
type Runner interface {
    Close() error
    Name() string
    TestUsability(ctx context.Context) bool
    OCIImageLoader() Loader
    StartPod(ctx context.Context, cfg *Config) error
    Run(ctx context.Context, cfg *Config, envOverride map[string]string, cmd ...string) error
    TerminatePod(ctx context.Context, cfg *Config) error
    TempDir() string
}
```

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] `go vet ./...` passes
- [x] `go mod tidy` is clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)