### PR TITLE
test: improve pkg/build coverage from 35% to 40%

### DIFF
--- a/pkg/build/build_helpers_test.go
+++ b/pkg/build/build_helpers_test.go
@@ -1,0 +1,345 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"github.com/chainguard-dev/clog/slogtest"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlorenc/melange2/pkg/config"
+)
+
+func TestCopyFile(t *testing.T) {
+	t.Run("copies file successfully", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcDir := filepath.Join(tmpDir, "src")
+		destDir := filepath.Join(tmpDir, "dest")
+		require.NoError(t, os.MkdirAll(srcDir, 0o755))
+
+		// Create source file
+		srcContent := []byte("test content")
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "test.txt"), srcContent, 0o644))
+
+		// Copy file
+		err := copyFile(srcDir, "test.txt", destDir, 0o644)
+		require.NoError(t, err)
+
+		// Verify copy
+		content, err := os.ReadFile(filepath.Join(destDir, "test.txt"))
+		require.NoError(t, err)
+		require.Equal(t, srcContent, content)
+	})
+
+	t.Run("copies file with subdirectory", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcDir := filepath.Join(tmpDir, "src")
+		destDir := filepath.Join(tmpDir, "dest")
+		require.NoError(t, os.MkdirAll(filepath.Join(srcDir, "subdir"), 0o755))
+
+		// Create source file in subdirectory
+		srcContent := []byte("nested content")
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "subdir", "nested.txt"), srcContent, 0o644))
+
+		// Copy file
+		err := copyFile(srcDir, "subdir/nested.txt", destDir, 0o644)
+		require.NoError(t, err)
+
+		// Verify copy
+		content, err := os.ReadFile(filepath.Join(destDir, "subdir", "nested.txt"))
+		require.NoError(t, err)
+		require.Equal(t, srcContent, content)
+	})
+
+	t.Run("preserves permissions", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		srcDir := filepath.Join(tmpDir, "src")
+		destDir := filepath.Join(tmpDir, "dest")
+		require.NoError(t, os.MkdirAll(srcDir, 0o755))
+
+		// Create source file
+		require.NoError(t, os.WriteFile(filepath.Join(srcDir, "exec.sh"), []byte("#!/bin/sh"), 0o755))
+
+		// Copy file with executable permissions
+		err := copyFile(srcDir, "exec.sh", destDir, 0o755)
+		require.NoError(t, err)
+
+		// Verify permissions
+		fi, err := os.Stat(filepath.Join(destDir, "exec.sh"))
+		require.NoError(t, err)
+		require.Equal(t, os.FileMode(0o755), fi.Mode().Perm())
+	})
+
+	t.Run("returns error for nonexistent file", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		err := copyFile(tmpDir, "nonexistent.txt", filepath.Join(tmpDir, "dest"), 0o644)
+		require.Error(t, err)
+	})
+}
+
+func TestLoadIgnoreRules(t *testing.T) {
+	t.Run("returns empty when no ignore file exists", func(t *testing.T) {
+		ctx := slogtest.Context(t)
+		tmpDir := t.TempDir()
+		b := &Build{
+			SourceDir:       tmpDir,
+			WorkspaceIgnore: ".melangeignore",
+		}
+
+		patterns, err := b.loadIgnoreRules(ctx)
+		require.NoError(t, err)
+		require.Empty(t, patterns)
+	})
+
+	t.Run("loads ignore patterns from file", func(t *testing.T) {
+		ctx := slogtest.Context(t)
+		tmpDir := t.TempDir()
+
+		// Create ignore file
+		ignoreContent := "*.tmp\n.git/\nnode_modules/"
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".melangeignore"), []byte(ignoreContent), 0o644))
+
+		b := &Build{
+			SourceDir:       tmpDir,
+			WorkspaceIgnore: ".melangeignore",
+		}
+
+		patterns, err := b.loadIgnoreRules(ctx)
+		require.NoError(t, err)
+		require.Len(t, patterns, 3)
+	})
+
+	t.Run("handles custom ignore file name", func(t *testing.T) {
+		ctx := slogtest.Context(t)
+		tmpDir := t.TempDir()
+
+		// Create custom ignore file
+		ignoreContent := "*.log"
+		require.NoError(t, os.WriteFile(filepath.Join(tmpDir, ".customignore"), []byte(ignoreContent), 0o644))
+
+		b := &Build{
+			SourceDir:       tmpDir,
+			WorkspaceIgnore: ".customignore",
+		}
+
+		patterns, err := b.loadIgnoreRules(ctx)
+		require.NoError(t, err)
+		require.Len(t, patterns, 1)
+	})
+}
+
+func TestGetBuildConfigPURL(t *testing.T) {
+	tests := []struct {
+		name       string
+		build      Build
+		wantPURL   string
+		wantErr    bool
+	}{
+		{
+			name: "valid github URL",
+			build: Build{
+				ConfigFileRepositoryURL:    "https://github.com/wolfi-dev/os",
+				ConfigFileRepositoryCommit: "abc123def456",
+				ConfigFile:                 "crane.yaml",
+			},
+			wantPURL: "pkg:github/wolfi-dev/os@abc123def456#crane.yaml",
+			wantErr:  false,
+		},
+		{
+			name: "github URL with nested config path",
+			build: Build{
+				ConfigFileRepositoryURL:    "https://github.com/chainguard-dev/packages",
+				ConfigFileRepositoryCommit: "deadbeef1234",
+				ConfigFile:                 "packages/go.yaml",
+			},
+			wantPURL: "pkg:github/chainguard-dev/packages@deadbeef1234#packages/go.yaml",
+			wantErr:  false,
+		},
+		{
+			name: "invalid URL format",
+			build: Build{
+				ConfigFileRepositoryURL:    "not-a-valid-url",
+				ConfigFileRepositoryCommit: "abc123",
+				ConfigFile:                 "test.yaml",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			purl, err := tt.build.getBuildConfigPURL()
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantPURL, purl.String())
+		})
+	}
+}
+
+func TestBuildFlavor(t *testing.T) {
+	tests := []struct {
+		name   string
+		libc   string
+		expect string
+	}{
+		{
+			name:   "empty returns gnu",
+			libc:   "",
+			expect: "gnu",
+		},
+		{
+			name:   "musl returns musl",
+			libc:   "musl",
+			expect: "musl",
+		},
+		{
+			name:   "glibc returns glibc",
+			libc:   "glibc",
+			expect: "glibc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &Build{Libc: tt.libc}
+			require.Equal(t, tt.expect, b.buildFlavor())
+		})
+	}
+}
+
+func TestApplyBuildOption(t *testing.T) {
+	t.Run("patches variables", func(t *testing.T) {
+		b := &Build{
+			Configuration: &config.Configuration{
+				Vars: map[string]string{"existing": "value"},
+			},
+		}
+
+		opt := config.BuildOption{
+			Vars: map[string]string{"new_var": "new_value"},
+		}
+
+		b.applyBuildOption(opt)
+		require.Equal(t, "value", b.Configuration.Vars["existing"])
+		require.Equal(t, "new_value", b.Configuration.Vars["new_var"])
+	})
+
+	t.Run("creates vars map if nil", func(t *testing.T) {
+		b := &Build{
+			Configuration: &config.Configuration{
+				Vars: nil,
+			},
+		}
+
+		opt := config.BuildOption{
+			Vars: map[string]string{"new_var": "new_value"},
+		}
+
+		b.applyBuildOption(opt)
+		require.NotNil(t, b.Configuration.Vars)
+		require.Equal(t, "new_value", b.Configuration.Vars["new_var"])
+	})
+
+	t.Run("adds packages", func(t *testing.T) {
+		b := &Build{
+			Configuration: &config.Configuration{
+				Environment: apko_types.ImageConfiguration{
+					Contents: apko_types.ImageContents{
+						Packages: []string{"pkg1"},
+					},
+				},
+			},
+		}
+
+		opt := config.BuildOption{
+			Environment: config.EnvironmentOption{
+				Contents: config.ContentsOption{
+					Packages: config.ListOption{
+						Add: []string{"pkg2", "pkg3"},
+					},
+				},
+			},
+		}
+
+		b.applyBuildOption(opt)
+		require.Contains(t, b.Configuration.Environment.Contents.Packages, "pkg1")
+		require.Contains(t, b.Configuration.Environment.Contents.Packages, "pkg2")
+		require.Contains(t, b.Configuration.Environment.Contents.Packages, "pkg3")
+	})
+
+	t.Run("removes packages", func(t *testing.T) {
+		b := &Build{
+			Configuration: &config.Configuration{
+				Environment: apko_types.ImageConfiguration{
+					Contents: apko_types.ImageContents{
+						Packages: []string{"pkg1", "pkg2", "pkg3"},
+					},
+				},
+			},
+		}
+
+		opt := config.BuildOption{
+			Environment: config.EnvironmentOption{
+				Contents: config.ContentsOption{
+					Packages: config.ListOption{
+						Remove: []string{"pkg2"},
+					},
+				},
+			},
+		}
+
+		b.applyBuildOption(opt)
+		require.Contains(t, b.Configuration.Environment.Contents.Packages, "pkg1")
+		require.NotContains(t, b.Configuration.Environment.Contents.Packages, "pkg2")
+		require.Contains(t, b.Configuration.Environment.Contents.Packages, "pkg3")
+	})
+}
+
+func TestPkgFromSub(t *testing.T) {
+	sub := &config.Subpackage{
+		Name:        "test-subpkg",
+		Description: "A test subpackage",
+		URL:         "https://example.com",
+		Commit:      "abc123",
+		Dependencies: config.Dependencies{
+			Runtime:  []string{"dep1"},
+			Provides: []string{"prov1"},
+		},
+		Options: &config.PackageOption{
+			NoProvides: true,
+		},
+		Scriptlets: &config.Scriptlets{
+			PreInstall: "echo pre",
+		},
+	}
+
+	pkg := pkgFromSub(sub)
+
+	require.Equal(t, "test-subpkg", pkg.Name)
+	require.Equal(t, "A test subpackage", pkg.Description)
+	require.Equal(t, "https://example.com", pkg.URL)
+	require.Equal(t, "abc123", pkg.Commit)
+	require.Equal(t, []string{"dep1"}, pkg.Dependencies.Runtime)
+	require.Equal(t, []string{"prov1"}, pkg.Dependencies.Provides)
+	require.True(t, pkg.Options.NoProvides)
+	require.Equal(t, "echo pre", pkg.Scriptlets.PreInstall)
+}

--- a/pkg/build/package_methods_test.go
+++ b/pkg/build/package_methods_test.go
@@ -1,0 +1,185 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlorenc/melange2/pkg/config"
+)
+
+func TestPackageBuildIdentity(t *testing.T) {
+	tests := []struct {
+		name     string
+		pb       *PackageBuild
+		expected string
+	}{
+		{
+			name: "simple package",
+			pb: &PackageBuild{
+				PackageName: "mypackage",
+				Origin: &config.Package{
+					Version: "1.0.0",
+					Epoch:   0,
+				},
+			},
+			expected: "mypackage-1.0.0-r0",
+		},
+		{
+			name: "package with epoch",
+			pb: &PackageBuild{
+				PackageName: "test-pkg",
+				Origin: &config.Package{
+					Version: "2.3.4",
+					Epoch:   5,
+				},
+			},
+			expected: "test-pkg-2.3.4-r5",
+		},
+		{
+			name: "package with complex version",
+			pb: &PackageBuild{
+				PackageName: "complex",
+				Origin: &config.Package{
+					Version: "1.2.3_alpha1",
+					Epoch:   10,
+				},
+			},
+			expected: "complex-1.2.3_alpha1-r10",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.pb.Identity())
+		})
+	}
+}
+
+func TestPackageBuildFilename(t *testing.T) {
+	pb := &PackageBuild{
+		PackageName: "testpkg",
+		OutDir:      "/output/x86_64",
+		Origin: &config.Package{
+			Version: "1.0.0",
+			Epoch:   0,
+		},
+	}
+
+	expected := "/output/x86_64/testpkg-1.0.0-r0.apk"
+	require.Equal(t, expected, pb.Filename())
+}
+
+func TestPackageBuildProvenanceFilename(t *testing.T) {
+	pb := &PackageBuild{
+		PackageName: "testpkg",
+		OutDir:      "/output/aarch64",
+		Origin: &config.Package{
+			Version: "2.0.0",
+			Epoch:   1,
+		},
+	}
+
+	expected := "/output/aarch64/testpkg-2.0.0-r1.attest.tar.gz"
+	require.Equal(t, expected, pb.ProvenanceFilename())
+}
+
+func TestPackageBuildSignatureName(t *testing.T) {
+	tests := []struct {
+		name       string
+		signingKey string
+		expected   string
+	}{
+		{
+			name:       "simple key name",
+			signingKey: "/keys/signing.rsa",
+			expected:   ".SIGN.RSA.signing.rsa.pub",
+		},
+		{
+			name:       "key with path",
+			signingKey: "/var/lib/melange/keys/wolfi-signing.rsa",
+			expected:   ".SIGN.RSA.wolfi-signing.rsa.pub",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pb := &PackageBuild{
+				Build: &Build{
+					SigningKey: tt.signingKey,
+				},
+			}
+			require.Equal(t, tt.expected, pb.SignatureName())
+		})
+	}
+}
+
+func TestPackageBuildWorkspaceSubdir(t *testing.T) {
+	pb := &PackageBuild{
+		PackageName: "mypackage",
+		Build: &Build{
+			WorkspaceDir: "/workspace/build",
+		},
+	}
+
+	expected := "/workspace/build/melange-out/mypackage"
+	require.Equal(t, expected, pb.WorkspaceSubdir())
+}
+
+func TestPackageBuildWantSignature(t *testing.T) {
+	t.Run("wants signature when key is set", func(t *testing.T) {
+		pb := &PackageBuild{
+			Build: &Build{
+				SigningKey: "/keys/signing.rsa",
+			},
+		}
+		require.True(t, pb.wantSignature())
+	})
+
+	t.Run("does not want signature when key is empty", func(t *testing.T) {
+		pb := &PackageBuild{
+			Build: &Build{
+				SigningKey: "",
+			},
+		}
+		require.False(t, pb.wantSignature())
+	})
+}
+
+func TestRemoveSelfProvidedDeps_SoVerDeps(t *testing.T) {
+	// Test so-ver: dependencies - the ">=" part gets stripped but so-ver: prefix remains
+	// so-ver:libtest.so.1>=1.0.0 becomes so-ver:libtest.so.1
+	// This will NOT match so:libtest.so.1 because the prefixes differ
+	provides := []string{"so-ver:libtest.so.1=1.0.0"}
+	depends := []string{"so-ver:libtest.so.1>=1.0.0", "so:libother.so.2"}
+
+	final := removeSelfProvidedDeps(depends, provides)
+
+	// so-ver:libtest.so.1>=1.0.0 becomes so-ver:libtest.so.1, which matches so-ver:libtest.so.1
+	require.Len(t, final, 1)
+	require.Equal(t, "so:libother.so.2", final[0])
+}
+
+func TestRemoveSelfProvidedDeps_MultipleProvides(t *testing.T) {
+	provides := []string{"so:liba.so.1=1", "so:libb.so.2=2", "so:libc.so.3=3"}
+	depends := []string{"so:liba.so.1", "so:libb.so.2", "so:libd.so.4"}
+
+	final := removeSelfProvidedDeps(depends, provides)
+
+	require.Len(t, final, 1)
+	require.Equal(t, "so:libd.so.4", final[0])
+}

--- a/pkg/build/runner_test.go
+++ b/pkg/build/runner_test.go
@@ -1,0 +1,32 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetAllRunners(t *testing.T) {
+	runners := GetAllRunners()
+
+	require.NotEmpty(t, runners)
+	require.Contains(t, runners, RunnerDocker)
+}
+
+func TestRunnerConstants(t *testing.T) {
+	require.Equal(t, Runner("docker"), RunnerDocker)
+}

--- a/pkg/build/sca_interface_test.go
+++ b/pkg/build/sca_interface_test.go
@@ -1,0 +1,202 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package build
+
+import (
+	"testing"
+
+	apko_types "chainguard.dev/apko/pkg/build/types"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dlorenc/melange2/pkg/config"
+)
+
+func TestSCABuildInterface_PackageName(t *testing.T) {
+	scabi := &SCABuildInterface{
+		PackageBuild: &PackageBuild{
+			PackageName: "test-package",
+		},
+	}
+
+	require.Equal(t, "test-package", scabi.PackageName())
+}
+
+func TestSCABuildInterface_RelativeNames(t *testing.T) {
+	t.Run("main package only", func(t *testing.T) {
+		scabi := &SCABuildInterface{
+			PackageBuild: &PackageBuild{
+				Origin: &config.Package{Name: "main-pkg"},
+				Build: &Build{
+					Configuration: &config.Configuration{
+						Subpackages: []config.Subpackage{},
+					},
+				},
+			},
+		}
+
+		names := scabi.RelativeNames()
+		require.Len(t, names, 1)
+		require.Contains(t, names, "main-pkg")
+	})
+
+	t.Run("main package with subpackages", func(t *testing.T) {
+		scabi := &SCABuildInterface{
+			PackageBuild: &PackageBuild{
+				Origin: &config.Package{Name: "main-pkg"},
+				Build: &Build{
+					Configuration: &config.Configuration{
+						Subpackages: []config.Subpackage{
+							{Name: "sub1"},
+							{Name: "sub2"},
+							{Name: "sub3"},
+						},
+					},
+				},
+			},
+		}
+
+		names := scabi.RelativeNames()
+		require.Len(t, names, 4)
+		require.Contains(t, names, "main-pkg")
+		require.Contains(t, names, "sub1")
+		require.Contains(t, names, "sub2")
+		require.Contains(t, names, "sub3")
+	})
+}
+
+func TestSCABuildInterface_Version(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		epoch    uint64
+		expected string
+	}{
+		{
+			name:     "simple version",
+			version:  "1.0.0",
+			epoch:    0,
+			expected: "1.0.0-r0",
+		},
+		{
+			name:     "version with epoch",
+			version:  "2.3.4",
+			epoch:    5,
+			expected: "2.3.4-r5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scabi := &SCABuildInterface{
+				PackageBuild: &PackageBuild{
+					Origin: &config.Package{
+						Version: tt.version,
+						Epoch:   tt.epoch,
+					},
+				},
+			}
+			require.Equal(t, tt.expected, scabi.Version())
+		})
+	}
+}
+
+func TestSCABuildInterface_Options(t *testing.T) {
+	t.Run("returns empty options when nil", func(t *testing.T) {
+		scabi := &SCABuildInterface{
+			PackageBuild: &PackageBuild{
+				Options: nil,
+			},
+		}
+
+		opts := scabi.Options()
+		require.False(t, opts.NoProvides)
+		require.False(t, opts.NoDepends)
+	})
+
+	t.Run("returns configured options", func(t *testing.T) {
+		scabi := &SCABuildInterface{
+			PackageBuild: &PackageBuild{
+				Options: &config.PackageOption{
+					NoProvides: true,
+					NoDepends:  true,
+				},
+			},
+		}
+
+		opts := scabi.Options()
+		require.True(t, opts.NoProvides)
+		require.True(t, opts.NoDepends)
+	})
+}
+
+func TestSCABuildInterface_BaseDependencies(t *testing.T) {
+	scabi := &SCABuildInterface{
+		PackageBuild: &PackageBuild{
+			Dependencies: config.Dependencies{
+				Runtime:  []string{"dep1", "dep2"},
+				Provides: []string{"prov1"},
+			},
+		},
+	}
+
+	deps := scabi.BaseDependencies()
+	require.Equal(t, []string{"dep1", "dep2"}, deps.Runtime)
+	require.Equal(t, []string{"prov1"}, deps.Provides)
+}
+
+func TestSCABuildInterface_InstalledPackages(t *testing.T) {
+	scabi := &SCABuildInterface{
+		PackageBuild: &PackageBuild{
+			Origin: &config.Package{Name: "main-pkg"},
+			Build: &Build{
+				Configuration: &config.Configuration{
+					Environment: apko_types.ImageConfiguration{
+						Contents: apko_types.ImageContents{
+							Packages: []string{"pkg1=1.0.0", "pkg2=2.0.0", "pkg3"},
+						},
+					},
+					Subpackages: []config.Subpackage{
+						{Name: "sub1"},
+					},
+				},
+			},
+		},
+	}
+
+	installed := scabi.InstalledPackages()
+
+	// Check environment packages
+	require.Equal(t, "1.0.0", installed["pkg1"])
+	require.Equal(t, "2.0.0", installed["pkg2"])
+	require.Equal(t, "", installed["pkg3"]) // No version specified
+
+	// Check that packages being built get @CURRENT@
+	require.Equal(t, "@CURRENT@", installed["main-pkg"])
+	require.Equal(t, "@CURRENT@", installed["sub1"])
+}
+
+func TestSCABuildInterface_PkgResolver(t *testing.T) {
+	t.Run("returns nil when not set", func(t *testing.T) {
+		scabi := &SCABuildInterface{
+			PackageBuild: &PackageBuild{
+				Build: &Build{
+					PkgResolver: nil,
+				},
+			},
+		}
+
+		require.Nil(t, scabi.PkgResolver())
+	})
+}


### PR DESCRIPTION
## Summary
- Add comprehensive unit tests for pure functions and interfaces in pkg/build
- Improves coverage from 34.7% to 40.3%

## Changes
New test files:
- `build_helpers_test.go`: Tests for `copyFile`, `loadIgnoreRules`, `getBuildConfigPURL`, `buildFlavor`, `applyBuildOption`, `pkgFromSub`
- `package_methods_test.go`: Tests for `Identity`, `Filename`, `ProvenanceFilename`, `SignatureName`, `WorkspaceSubdir`, `wantSignature`, and additional `removeSelfProvidedDeps` scenarios
- `sca_interface_test.go`: Tests for `SCABuildInterface` methods (`PackageName`, `RelativeNames`, `Version`, `Options`, `BaseDependencies`, `InstalledPackages`, `PkgResolver`)
- `runner_test.go`: Tests for `GetAllRunners` and `Runner` constants

## Test plan
- [x] All new tests pass locally with `go test -short ./pkg/build/...`
- [x] Full test suite passes with `go test -short ./...`
- [x] `go vet` reports no issues

Relates to #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)