### PR TITLE
test: add e2e tests for cache mount persistence and isolation

### DIFF
--- a/pkg/buildkit/testdata/e2e/16-cache-mounts.yaml
+++ b/pkg/buildkit/testdata/e2e/16-cache-mounts.yaml
@@ -1,0 +1,23 @@
+package:
+  name: cache-test
+  version: 1.0.0
+  epoch: 0
+  description: Test cache mount persistence
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - name: Write to cache
+    runs: |
+      # Write a marker file to the cache directory
+      mkdir -p /cache
+      echo "build-$BUILD_ID" >> /cache/builds.txt
+      wc -l < /cache/builds.txt > /cache/count.txt
+
+      # Copy cache contents to output for verification
+      mkdir -p ${{targets.destdir}}/usr/share/cache-test
+      cp /cache/builds.txt ${{targets.destdir}}/usr/share/cache-test/
+      cp /cache/count.txt ${{targets.destdir}}/usr/share/cache-test/


### PR DESCRIPTION
## Summary

Adds YAML-based e2e tests to verify cache mount behavior:

1. **`TestE2E_CacheMountPersistence`**: Runs 3 builds with the same cache ID and verifies:
   - First build writes "build-1" to cache
   - Second build sees "build-1" AND writes "build-2"
   - Third build sees all 3 entries (proves cache persists)

2. **`TestE2E_CacheMountIsolation`**: Verifies different cache IDs are isolated:
   - Build with cache-a writes data
   - Build with cache-b does NOT see cache-a's data

## Files Changed

- `pkg/buildkit/e2e_test.go` - Added `buildConfigWithCacheMounts()` helper and 2 new tests
- `pkg/buildkit/testdata/e2e/16-cache-mounts.yaml` - Test fixture that writes to /cache

## Test plan

- [x] Unit tests pass (`go test -short ./...`)
- [x] go vet passes
- [ ] CI checks (E2E tests will actually run these)

🤖 Generated with [Claude Code](https://claude.com/claude-code)