### PR TITLE
feat: add --cache-dir support for BuildKit builds

### DIFF
--- a/pkg/build/build_buildkit.go
+++ b/pkg/build/build_buildkit.go
@@ -155,6 +155,7 @@ func (b *Build) buildPackageBuildKit(ctx context.Context) error {
 		BaseEnv:      baseEnv,
 		SourceDir:    b.SourceDir,
 		WorkspaceDir: b.WorkspaceDir,
+		CacheDir:     b.CacheDir,
 		Debug:        b.Debug,
 	}
 

--- a/pkg/buildkit/builder.go
+++ b/pkg/buildkit/builder.go
@@ -112,6 +112,11 @@ type BuildConfig struct {
 	// WorkspaceDir is the directory where build output will be exported.
 	WorkspaceDir string
 
+	// CacheDir is the host directory to mount at /var/cache/melange.
+	// This enables sharing cached artifacts (fetch downloads, Go modules, etc.)
+	// from the host filesystem into the build.
+	CacheDir string
+
 	// Debug enables shell debugging (set -x).
 	Debug bool
 }
@@ -152,6 +157,13 @@ func (b *Builder) Build(ctx context.Context, layer v1.Layer, cfg *BuildConfig) e
 		sourceLocalName := "source"
 		state = CopySourceToWorkspace(state, sourceLocalName)
 		localDirs[sourceLocalName] = cfg.SourceDir
+	}
+
+	// If we have a cache directory, copy it to /var/cache/melange
+	if cfg.CacheDir != "" {
+		log.Infof("copying cache from %s to %s", cfg.CacheDir, DefaultCacheDir)
+		state = CopyCacheToWorkspace(state, CacheLocalName)
+		localDirs[CacheLocalName] = cfg.CacheDir
 	}
 
 	// Create subpackage output directories

--- a/pkg/buildkit/llb.go
+++ b/pkg/buildkit/llb.go
@@ -33,6 +33,13 @@ const (
 
 	// DefaultPath is the default PATH for pipeline execution.
 	DefaultPath = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+	// DefaultCacheDir is the default path where the melange cache is mounted.
+	// This is used for caching fetch artifacts, Go modules, etc.
+	DefaultCacheDir = "/var/cache/melange"
+
+	// CacheLocalName is the name used for the cache directory local mount.
+	CacheLocalName = "cache"
 )
 
 // PipelineBuilder converts melange pipelines to BuildKit LLB.
@@ -211,5 +218,17 @@ func ExportWorkspace(state llb.State) llb.State {
 			CopyDirContentsOnly: true,
 		}),
 		llb.WithCustomName("export workspace"),
+	)
+}
+
+// CopyCacheToWorkspace copies cache files from a Local mount to /var/cache/melange.
+// This enables pre-populating the cache from the host filesystem.
+func CopyCacheToWorkspace(base llb.State, localName string) llb.State {
+	return base.File(
+		llb.Copy(llb.Local(localName), "/", DefaultCacheDir+"/", &llb.CopyInfo{
+			CopyDirContentsOnly: true,
+			CreateDestPath:      true,
+		}),
+		llb.WithCustomName("copy cache to workspace"),
 	)
 }

--- a/pkg/buildkit/testdata/e2e/22-cache-dir.yaml
+++ b/pkg/buildkit/testdata/e2e/22-cache-dir.yaml
@@ -1,0 +1,24 @@
+package:
+  name: cache-dir-test
+  version: 1.0.0
+  epoch: 0
+  description: Test --cache-dir host filesystem mount
+
+environment:
+  contents:
+    packages:
+      - busybox
+
+pipeline:
+  - name: Read from cache directory
+    runs: |
+      # Read cached artifact from /var/cache/melange
+      mkdir -p ${{targets.destdir}}/usr/share/cache-dir-test
+
+      # Copy the cached artifact to output
+      if [ -f /var/cache/melange/test-artifact.txt ]; then
+        cp /var/cache/melange/test-artifact.txt ${{targets.destdir}}/usr/share/cache-dir-test/
+        echo "found" > ${{targets.destdir}}/usr/share/cache-dir-test/status.txt
+      else
+        echo "not-found" > ${{targets.destdir}}/usr/share/cache-dir-test/status.txt
+      fi


### PR DESCRIPTION
## Summary

Implements issue #25: The `--cache-dir` flag now works with BuildKit builds, mounting a host directory at `/var/cache/melange` inside the build container.

This enables:
- **Pre-populating cache** with host files (Go modules, fetch artifacts)
- **Sharing cached artifacts** from the host filesystem
- **Using existing local caches** without re-downloading

## How it works

```
Host filesystem                    Build container
~/.cache/melange/  ──copy──>  /var/cache/melange/
```

The host directory is copied into the build at `/var/cache/melange` using `llb.Local()` + `llb.Copy()`. This is different from BuildKit cache mounts which are internal to BuildKit.

| Feature | Host Cache (`--cache-dir`) | BuildKit Cache Mounts |
|---------|---------------------------|----------------------|
| Storage | Host filesystem | BuildKit-internal volumes |
| Pre-population | Yes | No |
| Sync back to host | No | No |
| Survives BuildKit restart | Yes | No |

## Changes

- `pkg/buildkit/llb.go`: Add `DefaultCacheDir`, `CacheLocalName` constants and `CopyCacheToWorkspace()` function
- `pkg/buildkit/builder.go`: Add `CacheDir` to `BuildConfig`, handle in `Build()`
- `pkg/build/build_buildkit.go`: Pass `CacheDir` to `BuildConfig`
- `pkg/buildkit/llb_test.go`: Add unit and integration tests
- `pkg/buildkit/e2e_test.go`: Add e2e tests for cache directory
- `pkg/buildkit/testdata/e2e/22-cache-dir.yaml`: Test fixture
- `docs/BUILDKIT-ARCHITECTURE.md`: Document cache directory feature

## Limitations

Changes made to `/var/cache/melange` during the build do NOT sync back to the host. The cache is read-only from the host's perspective. This is a fundamental limitation of how BuildKit handles local sources.

## Test plan

- [x] Unit tests for `CopyCacheToWorkspace` function
- [x] Integration test with real BuildKit
- [x] E2E tests: cache found, cache empty, cache not specified
- [x] All existing tests pass

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)