### PR TITLE
fix: e2e test helper now creates subpackage directories

### DIFF
--- a/pkg/buildkit/testdata/e2e/25-go-build.yaml
+++ b/pkg/buildkit/testdata/e2e/25-go-build.yaml
@@ -82,3 +82,13 @@ pipeline:
       EXP_EOF
 
       echo "experiments-done" >> ${{targets.destdir}}/usr/share/go-build-test/status.txt
+
+subpackages:
+  - name: go-build-test-compat
+    description: Compatibility symlinks
+    pipeline:
+      - runs: |
+          # Create compatibility symlinks for the binary
+          # Note: ${{targets.subpkgdir}} should now be pre-created by the framework
+          mkdir -p ${{targets.subpkgdir}}/usr/bin
+          echo "symlink: go-build-test-compat -> go-build-test" > ${{targets.subpkgdir}}/usr/bin/compat-link.txt


### PR DESCRIPTION
## Summary

The e2e test helper `buildConfig()` was missing the subpackage directory creation step that exists in the production `Builder.Build()` method. This caused tests with subpackages to fail when they expected directories to already exist.

### Root Cause

**Production code (`builder.go:169-175`)** creates subpackage directories before running pipelines:
```go
for _, sp := range cfg.Subpackages {
    state = state.File(
        llb.Mkdir(WorkspaceOutputDir(sp.Name), 0755, llb.WithParents(true)),
    )
}
```

**E2E test helper** was missing this step.

### Changes

1. **Add subpackage directory creation** to `buildConfig()` - now matches production behavior
2. **Fix `substituteVariables()`** - uses actual subpackage name for `${{targets.subpkgdir}}` instead of a generic suffix
3. **Restore subpackage test** in `25-go-build.yaml` that was removed as a workaround

### Why This Matters

- E2E tests now more accurately reflect production behavior
- Tests can use `${{targets.subpkgdir}}` expecting directories to exist (like production)
- Removes need for workarounds in test configurations

## Test Plan

- [x] `go test -short ./pkg/buildkit/...` passes locally
- [ ] CI passes (Build, Test, E2E, Lint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)