### PR TITLE
fix: ensure files are writable before stripping binaries

### DIFF
--- a/pkg/build/pipelines/strip.yaml
+++ b/pkg/build/pipelines/strip.yaml
@@ -19,5 +19,8 @@ pipeline:
 
         [ "$osabi" != "STANDALONE" ] || continue
         # scanelf may have picked up a temp file so verify that file still exists
+        # Ensure file is writable before stripping (needed when running as non-root)
+        [ ! -e "$filename" ] && continue
+        chmod u+w "${filename}" 2>/dev/null || true
         strip ${{inputs.opts}} "${filename}" || [ ! -e "$filename" ]
       done


### PR DESCRIPTION
## Summary
- Adds `chmod u+w` step before stripping binaries in the strip pipeline
- Fixes permission denied errors when running as build user (UID 1000)
- Handles Perl's ExtUtils::MakeMaker which installs files with restrictive permissions (444/555)

## Root Cause
When running builds as the build user (UID 1000) instead of root, some build tools install files with more restrictive permissions. The strip command needs write permission to modify binaries, so this fails without the chmod fix.

## Test plan
- [x] Built perl-io-gzip successfully after this fix
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)