### PR TITLE
refactor: remove unused build configuration fields

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -34,7 +34,6 @@ import (
 	apkofs "chainguard.dev/apko/pkg/apk/fs"
 	apko_types "chainguard.dev/apko/pkg/build/types"
 	"chainguard.dev/apko/pkg/options"
-	"chainguard.dev/apko/pkg/tarfs"
 	"github.com/chainguard-dev/clog"
 	purl "github.com/package-url/packageurl-go"
 	"github.com/zealic/xignore"
@@ -74,7 +73,6 @@ type Build struct {
 	WorkspaceDir    string
 	WorkspaceDirFS  apkofs.FullFS
 	WorkspaceIgnore string
-	GuestFS         apkofs.FullFS
 	// Ordered directories where to find 'uses' pipelines.
 	PipelineDirs          []string
 	SourceDir             string
@@ -89,13 +87,11 @@ type Build struct {
 	ExtraKeys             []string
 	ExtraRepos            []string
 	ExtraPackages         []string
-	DependencyLog         string
-	BinShOverlay          string
-	CreateBuildLog        bool
+	DependencyLog  string
+	CreateBuildLog bool
 	PersistLintResults    bool
-	CacheDir              string
-	ApkCacheDir           string
-	CacheSource           string
+	CacheDir        string
+	ApkCacheDir     string
 	StripOriginName bool
 	EnvFile               string
 	VarsFile              string
@@ -143,7 +139,6 @@ func New(ctx context.Context, opts ...Option) (*Build, error) {
 		OutDir:          ".",
 		CacheDir:        "./melange-cache/",
 		Arch:            apko_types.ParseArchitecture(runtime.GOARCH),
-		GuestFS:         tarfs.New(),
 		Start:           time.Now(),
 		SBOMGenerator:   &spdx.Generator{},
 	}

--- a/pkg/build/options.go
+++ b/pkg/build/options.go
@@ -155,14 +155,6 @@ func WithCacheDir(cacheDir string) Option {
 	}
 }
 
-// WithCacheSource sets the cache source directory to use.  The cache will be
-// pre-populated from this source directory.
-func WithCacheSource(sourceDir string) Option {
-	return func(b *Build) error {
-		b.CacheSource = sourceDir
-		return nil
-	}
-}
 
 // WithSigningKey sets the signing key path to use.
 func WithSigningKey(signingKey string) Option {
@@ -226,14 +218,6 @@ func WithDependencyLog(logFile string) Option {
 	}
 }
 
-// WithBinShOverlay sets a filename to copy from when installing /bin/sh
-// into a build environment.
-func WithBinShOverlay(binShOverlay string) Option {
-	return func(b *Build) error {
-		b.BinShOverlay = binShOverlay
-		return nil
-	}
-}
 
 // WithStripOriginName determines whether the origin name should be stripped
 // from generated packages.  The APK solver uses origin names to flatten
@@ -383,9 +367,7 @@ func WithSBOMGenerator(generator sbom.Generator) Option {
 }
 
 // WithBuildKitAddr sets the BuildKit daemon address to use for builds.
-// When set, builds will use BuildKit instead of the container runner.
 // The address should be in the form "tcp://host:port" or "unix:///path/to/socket".
-// If empty, the traditional runner-based build is used.
 func WithBuildKitAddr(addr string) Option {
 	return func(b *Build) error {
 		b.BuildKitAddr = addr

--- a/pkg/build/options_test.go
+++ b/pkg/build/options_test.go
@@ -193,14 +193,6 @@ func TestWithCacheDir(t *testing.T) {
 	require.Equal(t, "/cache", b.CacheDir)
 }
 
-func TestWithCacheSource(t *testing.T) {
-	b := &Build{}
-	opt := WithCacheSource("/cache/source")
-	err := opt(b)
-	require.NoError(t, err)
-	require.Equal(t, "/cache/source", b.CacheSource)
-}
-
 func TestWithSigningKey(t *testing.T) {
 	t.Run("empty key is allowed", func(t *testing.T) {
 		b := &Build{}
@@ -278,14 +270,6 @@ func TestWithDependencyLog(t *testing.T) {
 	err := opt(b)
 	require.NoError(t, err)
 	require.Equal(t, "/var/log/deps.log", b.DependencyLog)
-}
-
-func TestWithBinShOverlay(t *testing.T) {
-	b := &Build{}
-	opt := WithBinShOverlay("/custom/sh")
-	err := opt(b)
-	require.NoError(t, err)
-	require.Equal(t, "/custom/sh", b.BinShOverlay)
 }
 
 func TestWithStripOriginName(t *testing.T) {

--- a/pkg/build/package.go
+++ b/pkg/build/package.go
@@ -499,8 +499,9 @@ func (pc *PackageBuild) EmitPackage(ctx context.Context) error {
 		return fmt.Errorf("failed to return filesystem for workspace subtree: %w", err)
 	}
 
-	// provide the tar writer etc/passwd and etc/group of guest filesystem
-	userinfofs := pc.Build.GuestFS
+	// Use WorkspaceDirFS for user/group info lookups.
+	// The tarball writer will gracefully handle missing etc/passwd and etc/group.
+	userinfofs := pc.Build.WorkspaceDirFS
 
 	hdl := &SCABuildInterface{
 		PackageBuild: pc,

--- a/pkg/build/test_buildkit.go
+++ b/pkg/build/test_buildkit.go
@@ -50,10 +50,9 @@ type TestBuildKit struct {
 	ExtraKeys         []string
 	ExtraRepos        []string
 	ExtraTestPackages []string
-	CacheDir          string
-	ApkCacheDir       string
-	CacheSource       string
-	EnvFile           string
+	CacheDir    string
+	ApkCacheDir string
+	EnvFile     string
 	Debug             bool
 	Auth              map[string]options.Auth
 	IgnoreSignatures  bool

--- a/pkg/cli/build.go
+++ b/pkg/cli/build.go
@@ -46,7 +46,6 @@ func addBuildFlags(fs *pflag.FlagSet, flags *BuildFlags) {
 	fs.StringVar(&flags.PipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	fs.StringVar(&flags.SourceDir, "source-dir", "", "directory used for included sources")
 	fs.StringVar(&flags.CacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
-	fs.StringVar(&flags.CacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
 	fs.StringVar(&flags.ApkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
 	fs.StringVar(&flags.SigningKey, "signing-key", "", "key to use for signing")
 	fs.StringVar(&flags.EnvFile, "env-file", "", "file to use for preloaded environment variables")
@@ -88,10 +87,9 @@ type BuildFlags struct {
 	BuildDate            string
 	WorkspaceDir         string
 	PipelineDir          string
-	SourceDir            string
-	CacheDir             string
-	CacheSource          string
-	ApkCacheDir          string
+	SourceDir   string
+	CacheDir    string
+	ApkCacheDir string
 	SigningKey           string
 	GenerateIndex        bool
 	EmptyWorkspace       bool
@@ -174,7 +172,6 @@ func (flags *BuildFlags) BuildOptions(ctx context.Context, args ...string) ([]bu
 		build.WithPipelineDir(flags.PipelineDir),
 		build.WithPipelineDir(BuiltinPipelineDir),
 		build.WithCacheDir(flags.CacheDir),
-		build.WithCacheSource(flags.CacheSource),
 		build.WithPackageCacheDir(flags.ApkCacheDir),
 		build.WithSigningKey(flags.SigningKey),
 		build.WithGenerateIndex(flags.GenerateIndex),

--- a/pkg/cli/compile.go
+++ b/pkg/cli/compile.go
@@ -36,7 +36,6 @@ func compile() *cobra.Command {
 	var pipelineDir string
 	var sourceDir string
 	var cacheDir string
-	var cacheSource string
 	var apkCacheDir string
 	var signingKey string
 	var generateIndex bool
@@ -105,7 +104,6 @@ func compile() *cobra.Command {
 				build.WithPipelineDir(pipelineDir),
 				build.WithPipelineDir(BuiltinPipelineDir),
 				build.WithCacheDir(cacheDir),
-				build.WithCacheSource(cacheSource),
 				build.WithPackageCacheDir(apkCacheDir),
 				build.WithSigningKey(signingKey),
 				build.WithGenerateIndex(generateIndex),
@@ -166,7 +164,6 @@ func compile() *cobra.Command {
 	cmd.Flags().StringVar(&pipelineDir, "pipeline-dir", "", "directory used to extend defined built-in pipelines")
 	cmd.Flags().StringVar(&sourceDir, "source-dir", "", "directory used for included sources")
 	cmd.Flags().StringVar(&cacheDir, "cache-dir", "./melange-cache/", "directory used for cached inputs")
-	cmd.Flags().StringVar(&cacheSource, "cache-source", "", "directory or bucket used for preloading the cache")
 	cmd.Flags().StringVar(&apkCacheDir, "apk-cache-dir", "", "directory used for cached apk packages (default is system-defined cache directory)")
 	cmd.Flags().StringVar(&signingKey, "signing-key", "", "key to use for signing")
 	cmd.Flags().StringVar(&envFile, "env-file", "", "file to use for preloaded environment variables")


### PR DESCRIPTION
## Summary

Remove fields and options that were either never used or no longer applicable now that melange2 uses BuildKit exclusively:

- **BinShOverlay**: was defined but never read (only assigned)
- **CacheSource**: was defined and exposed via CLI but never read
- **GuestFS**: was initialized to empty tarfs but never populated in BuildKit mode

Also updated the BuildKit option comment to remove references to the now-removed "container runner" alternative.

### Changes

- Removed `BinShOverlay` field from Build struct and `WithBinShOverlay` option
- Removed `CacheSource` field from Build struct, `WithCacheSource` option, and `--cache-source` CLI flag
- Removed `GuestFS` field from Build struct
- Changed `package.go` to use `WorkspaceDirFS` instead of `GuestFS` for user/group info lookups (gracefully handles missing etc/passwd and etc/group)
- Updated BuildKit option comment to remove runner references

**Net result:** -58 lines, +13 lines

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [x] `go vet ./...` passes
- [x] `go mod tidy` produces no changes

Part of the ongoing simplification effort tracked in #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)