### PR TITLE
fix: setup build user in integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,7 +65,7 @@ jobs:
           cache: true
 
       - name: Run e2e tests
-        run: go test -v -coverprofile=e2e-coverage.out -run "TestE2E_|TestBuildKit|TestSimpleLLB|TestLocalFilesystem|TestWorkspaceExport|TestDeterministicLLB|TestPipelineSimulation" ./pkg/buildkit/...
+        run: go test -v -coverprofile=e2e-coverage.out -run "TestE2E_|TestBuildKit|TestSimpleLLB|TestLocalFilesystem|TestWorkspaceExport|TestDeterministicLLB|TestPipelineSimulation|Integration" ./pkg/buildkit/...
 
       - name: Upload e2e coverage
         uses: actions/upload-artifact@v4

--- a/pkg/buildkit/apko_load_test.go
+++ b/pkg/buildkit/apko_load_test.go
@@ -401,6 +401,13 @@ func startBuildKitContainer(t *testing.T, ctx context.Context) *buildKitContaine
 	}
 }
 
+// testBaseState returns a base LLB state suitable for integration tests.
+// It sets up the build user in the test image since wolfi-base doesn't
+// include it by default.
+func testBaseState() llb.State {
+	return SetupBuildUser(llb.Image(TestBaseImage))
+}
+
 // Helper: Create a minimal tar.gz layer (simulating apko output)
 func createMinimalTarGzLayer(path string) error {
 	f, err := os.Create(path)

--- a/pkg/buildkit/builder_test.go
+++ b/pkg/buildkit/builder_test.go
@@ -158,8 +158,8 @@ echo "hello" > /home/build/melange-out/test-pkg/result.txt
 		},
 	}
 
-	// Build the LLB graph using alpine as base (since our test layer isn't a full rootfs)
-	state := PrepareWorkspace(llb.Image(TestBaseImage), "test-pkg")
+	// Build the LLB graph using test base state (with build user configured)
+	state := PrepareWorkspace(testBaseState(), "test-pkg")
 	state, err = pipeline.BuildPipelines(state, pipelines)
 	require.NoError(t, err)
 

--- a/pkg/buildkit/cache_test.go
+++ b/pkg/buildkit/cache_test.go
@@ -226,7 +226,7 @@ cp /cache/data.txt /home/build/melange-out/cache-test/
 		},
 	}
 
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state := PrepareWorkspace(base, "cache-test")
 	state, err = builder.BuildPipelines(state, pipelines)
 	require.NoError(t, err)
@@ -283,7 +283,7 @@ echo "done" > /home/build/melange-out/pkg1/status.txt
 		},
 	}
 
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state1 := PrepareWorkspace(base, "pkg1")
 	state1, err = builder1.BuildPipelines(state1, pipelines1)
 	require.NoError(t, err)

--- a/pkg/buildkit/llb_test.go
+++ b/pkg/buildkit/llb_test.go
@@ -294,8 +294,8 @@ echo "hello from pipeline" > /home/build/melange-out/test-pkg/output.txt
 		},
 	}
 
-	// Start with alpine and prepare workspace
-	base := llb.Image(TestBaseImage)
+	// Start with test base state (with build user) and prepare workspace
+	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 
 	// Run pipelines
@@ -355,7 +355,7 @@ echo "step1" >> /home/build/melange-out/test-pkg/log.txt
 		},
 	}
 
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 	state, err = builder.BuildPipeline(state, &pipeline)
 	require.NoError(t, err)
@@ -409,7 +409,7 @@ echo "LOCAL_VAR=$LOCAL_VAR" >> /home/build/melange-out/test-pkg/env.txt
 		},
 	}
 
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 	state, err = builder.BuildPipeline(state, &pipeline)
 	require.NoError(t, err)
@@ -468,7 +468,7 @@ echo "setup done" > /home/build/melange-out/test-pkg/status.txt
 		},
 	}
 
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 	state, err = builder.BuildPipelines(state, pipelines)
 	require.NoError(t, err)
@@ -628,7 +628,7 @@ cat /var/cache/melange/cached-artifact.txt > /home/build/melange-out/test-pkg/fr
 	}
 
 	// Build the LLB graph
-	base := llb.Image(TestBaseImage)
+	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 	state = CopyCacheToWorkspace(state, CacheLocalName)
 	state, err = builder.BuildPipeline(state, &pipeline)


### PR DESCRIPTION
## Summary
- Fix integration tests that fail because wolfi-base doesn't have a "build" user by default
- Add `testBaseState()` helper that sets up the build user before tests run
- Update CI to run all `*Integration` tests in the e2e job

## Problem
The wolfi-base image doesn't include the "build" user - it's normally created by apko during build environment setup. Integration tests were failing with:
```
unable to find user build: no matching entries in passwd file
```

## Solution
- Added `testBaseState()` helper in `apko_load_test.go` that calls `SetupBuildUser()` 
- Updated all integration tests to use `testBaseState()` instead of `llb.Image(TestBaseImage)`
- Added "Integration" pattern to CI e2e test job

## Test plan
- [x] All 10 integration tests now pass locally
- [x] All unit tests continue to pass
- [x] go vet passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)