### PR TITLE
fix: resolve lint errors in storage package

### DIFF
--- a/pkg/service/storage/local.go
+++ b/pkg/service/storage/local.go
@@ -97,7 +97,7 @@ func (s *LocalStorage) ListArtifacts(ctx context.Context, jobID string) ([]Artif
 		return nil, fmt.Errorf("reading artifact directory: %w", err)
 	}
 
-	var artifacts []Artifact
+	artifacts := make([]Artifact, 0, len(entries))
 	for _, entry := range entries {
 		if entry.IsDir() {
 			continue


### PR DESCRIPTION
## Summary
- Use `errors.Is()` instead of `==` for `iterator.Done` comparison (errorlint)
- Convert if-else chain to switch statement for content type detection (gocritic)
- Pre-allocate artifacts slice in `ListArtifacts` (prealloc)

## Test plan
- [x] `go build ./pkg/service/...` passes
- [ ] CI lint check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)