### PR TITLE
feat: support inline pipelines via API and --pipeline-dir CLI flag

### DIFF
--- a/pkg/service/types/types.go
+++ b/pkg/service/types/types.go
@@ -47,6 +47,11 @@ type JobSpec struct {
 	// ConfigYAML is the inline melange configuration.
 	ConfigYAML string `json:"config_yaml"`
 
+	// Pipelines is a map of pipeline paths to their YAML content.
+	// Keys should be relative paths like "test/docs.yaml" or "autoconf/configure.yaml".
+	// These pipelines are made available during the build.
+	Pipelines map[string]string `json:"pipelines,omitempty"`
+
 	// Arch is the target architecture (default: runtime arch).
 	Arch string `json:"arch,omitempty"`
 
@@ -59,10 +64,11 @@ type JobSpec struct {
 
 // CreateJobRequest is the request body for creating a job.
 type CreateJobRequest struct {
-	ConfigYAML string `json:"config_yaml"`
-	Arch       string `json:"arch,omitempty"`
-	WithTest   bool   `json:"with_test,omitempty"`
-	Debug      bool   `json:"debug,omitempty"`
+	ConfigYAML string            `json:"config_yaml"`
+	Pipelines  map[string]string `json:"pipelines,omitempty"`
+	Arch       string            `json:"arch,omitempty"`
+	WithTest   bool              `json:"with_test,omitempty"`
+	Debug      bool              `json:"debug,omitempty"`
 }
 
 // CreateJobResponse is the response body for creating a job.


### PR DESCRIPTION
## Summary

Add ability to include custom pipeline YAML files when submitting jobs to melange-server.

### API changes
- Add `pipelines` field to `JobSpec` and `CreateJobRequest`
- Pipelines are a map of relative paths (e.g., `test/docs.yaml`) to YAML content

### Server changes  
- Scheduler writes inline pipelines to a temp directory
- Pipeline directory is passed to build via `WithPipelineDir`

### CLI changes
- Add `--pipeline-dir` flag to `remote submit` command
- Reads all `.yaml` files from directory and includes them in request
- Can be specified multiple times for multiple directories

## Example

```bash
# Submit with pipelines from os/pipelines directory
melange remote submit os/hello-wolfi.yaml --pipeline-dir os/pipelines --wait
```

## Test plan
- [x] `go build` succeeds
- [x] `go vet` passes
- [ ] Manual test with os/pipelines directory

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)