### PR TITLE
feat: auto-inject Wolfi repos for packages without inline repos

### DIFF
--- a/docs/remote-builds.md
+++ b/docs/remote-builds.md
@@ -130,9 +130,20 @@ See [GKE Setup Guide](deployment/gke-setup.md) for detailed deployment instructi
 ### Build Defaults
 
 The server automatically configures builds with:
-- Wolfi OS repository and signing key
+- Wolfi OS repository and signing key (auto-injected if not specified)
 - Signature verification disabled (for MVP)
 - `wolfi` namespace for package URLs
+
+Packages without inline repository configuration will automatically use the default Wolfi repos:
+```yaml
+# These are auto-injected if your config doesn't specify repositories:
+environment:
+  contents:
+    repositories:
+      - https://packages.wolfi.dev/os
+    keyring:
+      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
+```
 
 ## Limitations
 
@@ -144,22 +155,6 @@ The server automatically configures builds with:
 4. **No job cancellation**: Running jobs cannot be cancelled
 5. **No live log streaming**: Logs available only after completion
 
-### Package Requirements
-
-Packages submitted to the server must include inline repository configuration:
-
-```yaml
-environment:
-  contents:
-    repositories:
-      - https://packages.wolfi.dev/os
-    keyring:
-      - https://packages.wolfi.dev/os/wolfi-signing.rsa.pub
-    packages:
-      - build-base
-      - ...
-```
-
 ---
 
 ## Roadmap
@@ -167,7 +162,7 @@ environment:
 ### Phase 1: Core Improvements (Next)
 
 - [ ] **PostgreSQL job store** - Persistent job storage across restarts
-- [ ] **Default repository injection** - Auto-add Wolfi repos for packages without inline repos
+- [x] **Default repository injection** - Auto-add Wolfi repos for packages without inline repos
 - [ ] **Job cancellation** - API endpoint to cancel running jobs
 - [ ] **Live log streaming** - WebSocket endpoint for real-time build logs
 - [ ] **Authentication** - API key or OAuth2 authentication

--- a/examples/no-inline-repos.yaml
+++ b/examples/no-inline-repos.yaml
@@ -1,0 +1,21 @@
+# Example package without inline repository configuration.
+# The server will auto-inject default Wolfi repos.
+package:
+  name: no-inline-repos-test
+  version: "1.0.0"
+  epoch: 0
+  description: "Test package without inline repos"
+  copyright:
+    - license: Apache-2.0
+
+environment:
+  contents:
+    # Note: no repositories or keyring specified here
+    # The server will automatically inject Wolfi repos
+    packages:
+      - busybox
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/test"
+      echo "Hello from no-inline-repos test" > "${{targets.destdir}}/usr/share/test/hello.txt"

--- a/pkg/build/build_buildkit.go
+++ b/pkg/build/build_buildkit.go
@@ -326,6 +326,17 @@ func (b *Build) buildGuestLayers(ctx context.Context) ([]v1.Layer, *apko_build.R
 	imgConfig := b.Configuration.Environment
 	imgConfig.Archs = []apko_types.Architecture{b.Arch}
 
+	// Inject default repositories if none are specified in the config
+	// This allows packages without inline repos to use the default Wolfi repos
+	if len(imgConfig.Contents.Repositories) == 0 && len(b.ExtraRepos) > 0 {
+		log.Infof("no repositories in config, using default repos: %v", b.ExtraRepos)
+		imgConfig.Contents.Repositories = append(imgConfig.Contents.Repositories, b.ExtraRepos...)
+	}
+	if len(imgConfig.Contents.Keyring) == 0 && len(b.ExtraKeys) > 0 {
+		log.Infof("no keyring in config, using default keys: %v", b.ExtraKeys)
+		imgConfig.Contents.Keyring = append(imgConfig.Contents.Keyring, b.ExtraKeys...)
+	}
+
 	// Set the layer budget based on MaxLayers configuration
 	// Default to 50 if not set
 	maxLayers := b.MaxLayers


### PR DESCRIPTION
## Summary
- Packages submitted to melange-server no longer need inline repo configuration
- If no repositories are specified, default Wolfi repos and keys are auto-injected
- Simplifies package submission by removing boilerplate

## Changes
- `pkg/build/build_buildkit.go`: Inject `ExtraRepos`/`ExtraKeys` into `imgConfig` when the config has no repos/keys
- `docs/remote-builds.md`: Updated docs and marked roadmap item complete
- `examples/no-inline-repos.yaml`: Added test example without inline repos

## How it works
In `buildGuestLayers()`, before passing `imgConfig` to apko:
```go
if len(imgConfig.Contents.Repositories) == 0 && len(b.ExtraRepos) > 0 {
    log.Infof("no repositories in config, using default repos: %v", b.ExtraRepos)
    imgConfig.Contents.Repositories = append(imgConfig.Contents.Repositories, b.ExtraRepos...)
}
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [ ] Deploy and test with `examples/no-inline-repos.yaml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)