### PR TITLE
feat: add dynamic backend management via API and CLI

### DIFF
--- a/docs/remote-builds.md
+++ b/docs/remote-builds.md
@@ -51,6 +51,8 @@ melange remote submit mypackage.yaml --arch aarch64 --debug
 | `GET /api/v1/jobs` | GET | List all jobs |
 | `GET /api/v1/jobs/:id` | GET | Get job status and details |
 | `GET /api/v1/backends` | GET | List available BuildKit backends |
+| `POST /api/v1/backends` | POST | Add a new backend |
+| `DELETE /api/v1/backends` | DELETE | Remove a backend |
 | `GET /healthz` | GET | Health check |
 
 ### Job Request Format
@@ -78,7 +80,9 @@ melange remote submit mypackage.yaml --arch aarch64 --debug
 | `melange remote status <job-id>` | Get job status |
 | `melange remote list` | List all jobs |
 | `melange remote wait <job-id>` | Wait for job completion |
-| `melange remote backends` | List available BuildKit backends |
+| `melange remote backends list` | List available BuildKit backends |
+| `melange remote backends add` | Add a new backend |
+| `melange remote backends remove` | Remove a backend |
 
 ### Inline Pipelines
 
@@ -176,10 +180,28 @@ melange remote submit pkg.yaml --arch x86_64 --backend-selector tier=high-memory
 
 **List available backends:**
 ```bash
-melange remote backends
+melange remote backends list
 
 # Filter by architecture
-melange remote backends --arch aarch64
+melange remote backends list --arch aarch64
+```
+
+**Dynamically add backends:**
+```bash
+# Add a basic backend
+melange remote backends add --addr tcp://new-buildkit:1234 --arch x86_64
+
+# Add a backend with labels
+melange remote backends add \
+  --addr tcp://high-memory-buildkit:1234 \
+  --arch x86_64 \
+  --label tier=high-memory \
+  --label sandbox=privileged
+```
+
+**Remove backends:**
+```bash
+melange remote backends remove --addr tcp://old-buildkit:1234
 ```
 
 The scheduler selects backends using:


### PR DESCRIPTION
## Summary

Add the ability to dynamically add and remove BuildKit backends at runtime without server restart.

- `Pool.Add()` and `Pool.Remove()` methods for dynamic backend management
- `POST /api/v1/backends` endpoint to add backends
- `DELETE /api/v1/backends` endpoint to remove backends
- `Client.AddBackend()` and `Client.RemoveBackend()` methods
- CLI commands: `melange remote backends add/remove/list`
- Updated documentation with examples

## Usage

**Add a new backend:**
```bash
melange remote backends add --addr tcp://buildkit:1234 --arch x86_64

# With labels
melange remote backends add --addr tcp://buildkit:1234 --arch aarch64 \
  --label tier=high-memory
```

**Remove a backend:**
```bash
melange remote backends remove --addr tcp://buildkit:1234
```

**List backends:**
```bash
melange remote backends list
```

## Test plan

- [x] Unit tests for Pool.Add() and Pool.Remove() methods
- [x] Build verification
- [ ] CI tests pass
- [ ] Manual testing with running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)