### PR TITLE
fix: deploy workflow missing backends.yaml in configmap

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -63,10 +63,9 @@ jobs:
 
       - name: Deploy ConfigMap
         run: |
-          kubectl create configmap melange-config \
-            --namespace=melange \
-            --from-literal=gcs-bucket="${{ env.GCS_BUCKET }}" \
-            --dry-run=client -o yaml | kubectl apply -f -
+          kubectl apply -f deploy/gke/configmap.yaml
+          kubectl patch configmap melange-config -n melange \
+            --type merge -p '{"data":{"gcs-bucket":"${{ env.GCS_BUCKET }}"}}'
 
       - name: Build and Deploy melange-server
         env:


### PR DESCRIPTION
## Summary
- The deploy workflow was creating the configmap with only `gcs-bucket`, but the melange-server deployment expects a `backends.yaml` key for the volume mount
- This caused pods to fail to start because the required configmap key didn't exist, leading to the "1 old replicas are pending termination" timeout

## Root Cause
The workflow was using:
```bash
kubectl create configmap melange-config \
  --from-literal=gcs-bucket="..." \
  --dry-run=client -o yaml | kubectl apply -f -
```

This completely replaced the configmap with only one key, removing the `backends.yaml` key that already existed from `deploy/gke/configmap.yaml`.

## Fix
Apply the full `configmap.yaml` file first (which includes `backends.yaml`), then patch to update the environment-specific `gcs-bucket` value.

## Test plan
- [ ] Merge and verify the Deploy to GKE workflow succeeds
- [ ] Verify melange-server pods start correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)