### PR TITLE
feat: configure GKE autoscaling with 8 BuildKit workers

### DIFF
--- a/deploy/gke/buildkit.yaml
+++ b/deploy/gke/buildkit.yaml
@@ -25,13 +25,47 @@ data:
       http = true
       insecure = true
 ---
-apiVersion: apps/v1
-kind: Deployment
+# Headless service for StatefulSet DNS resolution
+# Each pod gets a DNS name: buildkit-{0..N}.buildkit-headless.melange.svc.cluster.local
+apiVersion: v1
+kind: Service
+metadata:
+  name: buildkit-headless
+  namespace: melange
+spec:
+  clusterIP: None
+  selector:
+    app: buildkit
+  ports:
+  - port: 1234
+    targetPort: 1234
+    name: buildkit
+---
+# Regular service for load balancing (optional, for single-endpoint access)
+apiVersion: v1
+kind: Service
 metadata:
   name: buildkit
   namespace: melange
 spec:
-  replicas: 1
+  selector:
+    app: buildkit
+  ports:
+  - port: 1234
+    targetPort: 1234
+    name: buildkit
+---
+# StatefulSet for 8 BuildKit workers
+# Each pod gets a stable hostname and DNS entry for backend pool configuration
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: buildkit
+  namespace: melange
+spec:
+  serviceName: buildkit-headless
+  replicas: 8
+  podManagementPolicy: Parallel  # Start all pods simultaneously
   selector:
     matchLabels:
       app: buildkit
@@ -40,6 +74,22 @@ spec:
       labels:
         app: buildkit
     spec:
+      # Schedule on the dedicated BuildKit node pool
+      nodeSelector:
+        workload: buildkit
+      tolerations:
+      - key: workload
+        operator: Equal
+        value: buildkit
+        effect: NoSchedule
+      # Spread pods across nodes for better resource utilization
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app: buildkit
       containers:
       - name: buildkit
         image: moby/buildkit:latest
@@ -61,27 +111,24 @@ spec:
           readOnly: true
         resources:
           requests:
-            memory: "2Gi"
-            cpu: "1000m"
-          limits:
             memory: "8Gi"
-            cpu: "4000m"
+            cpu: "14000m"    # Request 14 of 16 cores
+          limits:
+            memory: "32Gi"
+            cpu: "16000m"    # Limit to all 16 cores
+        readinessProbe:
+          tcpSocket:
+            port: 1234
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        livenessProbe:
+          tcpSocket:
+            port: 1234
+          initialDelaySeconds: 15
+          periodSeconds: 20
       volumes:
       - name: buildkit-data
         emptyDir: {}
       - name: buildkit-config
         configMap:
           name: buildkit-config
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: buildkit
-  namespace: melange
-spec:
-  selector:
-    app: buildkit
-  ports:
-  - port: 1234
-    targetPort: 1234
-    name: buildkit

--- a/deploy/gke/configmap.yaml
+++ b/deploy/gke/configmap.yaml
@@ -28,15 +28,51 @@ data:
   cache-mode: "max"
 
   # BuildKit backends configuration
-  # Add more backends or modify labels as needed
+  # 8 BuildKit workers using StatefulSet DNS names
+  # Each worker can handle 16 concurrent jobs (matching 16-core machines)
   backends.yaml: |
     backends:
-      - addr: tcp://buildkit:1234
+      - addr: tcp://buildkit-0.buildkit-headless.melange.svc.cluster.local:1234
         arch: x86_64
-        maxJobs: 4
+        maxJobs: 16
         labels:
           tier: standard
-    # Pool-wide throttling configuration
-    defaultMaxJobs: 4        # Default max concurrent jobs per backend
+      - addr: tcp://buildkit-1.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-2.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-3.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-4.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-5.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-6.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+      - addr: tcp://buildkit-7.buildkit-headless.melange.svc.cluster.local:1234
+        arch: x86_64
+        maxJobs: 16
+        labels:
+          tier: standard
+    # Pool-wide configuration
+    defaultMaxJobs: 16       # Default max concurrent jobs per backend
     failureThreshold: 3      # Consecutive failures before circuit opens
     recoveryTimeout: 30s     # How long circuit stays open


### PR DESCRIPTION
## Summary

Infrastructure changes to support 200-package scale runs with automatic node scaling.

## Changes

### Node Pool Autoscaling (`setup.sh`)
- Add dedicated `buildkit-pool` with `n2-standard-16` machines (16 cores, 64GB RAM)
- Enable autoscaling: **0-8 nodes** based on pod demand
- Node taints/labels to isolate BuildKit workloads from other pods
- Default node pool also gets autoscaling (1-3 nodes)

### BuildKit StatefulSet (`buildkit.yaml`)
- Convert from Deployment to **StatefulSet with 8 replicas**
- Each pod gets stable DNS: `buildkit-{0..7}.buildkit-headless.melange.svc.cluster.local`
- Headless service for DNS discovery
- Resource requests: 14 CPU cores, 8Gi memory per pod
- Topology spread constraints for even node distribution
- Readiness/liveness probes for health checking

### Backend Configuration (`configmap.yaml`)
- 8 backends configured with full StatefulSet DNS names
- `maxJobs: 16` per backend (matches CPU cores)
- Total capacity: **128 concurrent package builds**

## Capacity

| Resource | Value |
|----------|-------|
| BuildKit workers | 8 |
| Jobs per worker | 16 |
| **Total concurrent builds** | **128** |
| Machine type | n2-standard-16 |
| Total vCPU | 128 |
| Autoscale range | 0-8 nodes |

## How Autoscaling Works

1. When BuildKit StatefulSet is deployed, GKE sees 8 pending pods
2. Cluster autoscaler provisions nodes from `buildkit-pool` (up to 8)
3. Pods are scheduled with topology spread (1 per node ideal)
4. When pods are deleted/scaled down, autoscaler removes idle nodes
5. Can scale to 0 nodes when no builds are running

## Test Plan

- [ ] Deploy to GKE with `./deploy/gke/setup.sh`
- [ ] Verify 8 BuildKit pods come up: `kubectl get pods -n melange`
- [ ] Verify node autoscaling: `kubectl get nodes`
- [ ] Test with scale run

🤖 Generated with [Claude Code](https://claude.com/claude-code)