### PR TITLE
fix: deploy workflow creates buildkit-pool and waits for StatefulSet

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -56,6 +56,33 @@ jobs:
           location: ${{ env.CLUSTER_ZONE }}
           project_id: ${{ env.PROJECT_ID }}
 
+      - name: Ensure BuildKit node pool with autoscaling
+        run: |
+          # Create buildkit-pool if it doesn't exist
+          if ! gcloud container node-pools describe buildkit-pool \
+              --cluster=${{ env.CLUSTER_NAME }} \
+              --zone=${{ env.CLUSTER_ZONE }} &>/dev/null; then
+            echo "Creating buildkit-pool with autoscaling..."
+            gcloud container node-pools create buildkit-pool \
+              --cluster=${{ env.CLUSTER_NAME }} \
+              --zone=${{ env.CLUSTER_ZONE }} \
+              --machine-type=n2-standard-16 \
+              --num-nodes=0 \
+              --enable-autoscaling \
+              --min-nodes=0 \
+              --max-nodes=8 \
+              --node-labels=workload=buildkit \
+              --node-taints=workload=buildkit:NoSchedule
+          else
+            echo "buildkit-pool already exists, ensuring autoscaling is enabled..."
+            gcloud container clusters update ${{ env.CLUSTER_NAME }} \
+              --zone=${{ env.CLUSTER_ZONE }} \
+              --node-pool=buildkit-pool \
+              --enable-autoscaling \
+              --min-nodes=0 \
+              --max-nodes=8 || true
+          fi
+
       - name: Deploy BuildKit and Registry
         run: |
           kubectl apply -f deploy/gke/namespace.yaml
@@ -79,7 +106,7 @@ jobs:
       - name: Wait for rollout
         run: |
           kubectl rollout status deployment/registry -n melange --timeout=180s
-          kubectl rollout status deployment/buildkit -n melange --timeout=180s
+          kubectl rollout status statefulset/buildkit -n melange --timeout=600s
           kubectl rollout status deployment/melange-server -n melange --timeout=180s
 
       - name: Verify deployment


### PR DESCRIPTION
## Summary

Fixes the deploy workflow to properly handle the new StatefulSet-based BuildKit deployment with autoscaling.

## Changes

1. **Create buildkit-pool with autoscaling** - The deploy workflow now creates the `buildkit-pool` node pool if it doesn't exist, with:
   - `n2-standard-16` machines (16 cores)
   - Autoscaling: 0-8 nodes
   - Node taints/labels for BuildKit isolation

2. **Fix StatefulSet rollout** - Changed from `deployment/buildkit` to `statefulset/buildkit` with 600s timeout (needs time for nodes to autoscale)

## Why This Is Needed

PR #96 changed BuildKit from Deployment to StatefulSet, but the deploy workflow still:
- Waited for `deployment/buildkit` (now fails)
- Didn't create the autoscaling node pool

## Test Plan

- [ ] Deploy runs successfully
- [ ] BuildKit pods come up on autoscaled nodes
- [ ] `kubectl get nodes` shows buildkit-pool nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)