### PR TITLE
feat: add observability with tracing and timing logs

### DIFF
--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -36,6 +36,7 @@ spec:
         - --listen-addr=:8080
         - --backends-config=/etc/melange/backends.yaml
         - --gcs-bucket=$(GCS_BUCKET)
+        - --enable-tracing
         env:
         - name: GCS_BUCKET
           valueFrom:

--- a/go.mod
+++ b/go.mod
@@ -197,7 +197,7 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.63.0 // indirect
 	go.opentelemetry.io/otel/metric v1.39.0 // indirect
-	go.opentelemetry.io/otel/trace v1.39.0 // indirect
+	go.opentelemetry.io/otel/trace v1.39.0
 	go.step.sm/crypto v0.75.0 // indirect
 	golang.org/x/mod v0.30.0 // indirect
 	golang.org/x/net v0.47.0 // indirect

--- a/pkg/service/storage/local.go
+++ b/pkg/service/storage/local.go
@@ -20,6 +20,8 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/chainguard-dev/clog"
 )
 
 // LocalStorage stores artifacts and logs on the local filesystem.
@@ -127,5 +129,7 @@ func (s *LocalStorage) OutputDir(ctx context.Context, jobID string) (string, err
 // SyncOutputDir is a no-op for local storage.
 func (s *LocalStorage) SyncOutputDir(ctx context.Context, jobID, localDir string) error {
 	// No-op for local storage - files are already in place
+	log := clog.FromContext(ctx)
+	log.Infof("storage sync: local storage, no upload needed for job %s (files at %s)", jobID, localDir)
 	return nil
 }

--- a/pkg/service/tracing/tracing.go
+++ b/pkg/service/tracing/tracing.go
@@ -1,0 +1,215 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tracing provides OpenTelemetry tracing setup for melange-server.
+package tracing
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/chainguard-dev/clog"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const (
+	// TracerName is the name of the tracer used throughout melange-server.
+	TracerName = "github.com/dlorenc/melange2/pkg/service"
+)
+
+// Tracer returns the tracer for melange-server.
+func Tracer() trace.Tracer {
+	return otel.Tracer(TracerName)
+}
+
+// Config holds tracing configuration.
+type Config struct {
+	// ServiceName is the name of the service.
+	ServiceName string
+	// ServiceVersion is the version of the service.
+	ServiceVersion string
+	// Enabled controls whether tracing is enabled.
+	Enabled bool
+}
+
+// Setup initializes the OpenTelemetry tracer provider.
+// Returns a shutdown function that should be called on exit.
+func Setup(ctx context.Context, cfg Config) (func(context.Context) error, error) {
+	if !cfg.Enabled {
+		// Return a no-op shutdown function
+		return func(context.Context) error { return nil }, nil
+	}
+
+	log := clog.FromContext(ctx)
+
+	// Create stdout exporter for now (can be replaced with OTLP exporter)
+	exporter, err := stdouttrace.New(
+		stdouttrace.WithPrettyPrint(),
+		stdouttrace.WithWriter(os.Stderr),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create resource with service info
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(cfg.ServiceName),
+			semconv.ServiceVersion(cfg.ServiceVersion),
+		),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create tracer provider
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+
+	// Set as global tracer provider
+	otel.SetTracerProvider(tp)
+
+	log.Info("tracing enabled")
+
+	return tp.Shutdown, nil
+}
+
+// StartSpan starts a new span with the given name.
+// Returns the context with the span and the span itself.
+func StartSpan(ctx context.Context, name string, opts ...trace.SpanStartOption) (context.Context, trace.Span) {
+	return Tracer().Start(ctx, name, opts...)
+}
+
+// SpanFromContext returns the current span from the context.
+func SpanFromContext(ctx context.Context) trace.Span {
+	return trace.SpanFromContext(ctx)
+}
+
+// AddEvent adds an event to the current span.
+func AddEvent(ctx context.Context, name string, attrs ...attribute.KeyValue) {
+	span := trace.SpanFromContext(ctx)
+	span.AddEvent(name, trace.WithAttributes(attrs...))
+}
+
+// SetAttributes sets attributes on the current span.
+func SetAttributes(ctx context.Context, attrs ...attribute.KeyValue) {
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(attrs...)
+}
+
+// RecordError records an error on the current span.
+func RecordError(ctx context.Context, err error) {
+	span := trace.SpanFromContext(ctx)
+	span.RecordError(err)
+}
+
+// Timer provides a simple way to measure and log durations.
+type Timer struct {
+	name      string
+	start     time.Time
+	ctx       context.Context
+	logged    bool
+	threshold time.Duration
+}
+
+// NewTimer creates a new timer with the given name.
+// The timer starts immediately.
+func NewTimer(ctx context.Context, name string) *Timer {
+	return &Timer{
+		name:      name,
+		start:     time.Now(),
+		ctx:       ctx,
+		threshold: 0,
+	}
+}
+
+// WithThreshold sets a minimum duration before logging.
+// Durations below the threshold are not logged.
+func (t *Timer) WithThreshold(d time.Duration) *Timer {
+	t.threshold = d
+	return t
+}
+
+// Stop stops the timer and logs the duration.
+// Returns the duration for use in other contexts.
+func (t *Timer) Stop() time.Duration {
+	if t.logged {
+		return time.Since(t.start)
+	}
+	t.logged = true
+
+	duration := time.Since(t.start)
+
+	// Add event to span
+	span := trace.SpanFromContext(t.ctx)
+	span.AddEvent(t.name+" completed",
+		trace.WithAttributes(attribute.String("duration", duration.String())),
+	)
+
+	// Log if above threshold
+	if duration >= t.threshold {
+		log := clog.FromContext(t.ctx)
+		log.Infof("%s took %s", t.name, duration)
+	}
+
+	return duration
+}
+
+// StopWithAttrs stops the timer and logs the duration with additional attributes.
+func (t *Timer) StopWithAttrs(attrs ...attribute.KeyValue) time.Duration {
+	if t.logged {
+		return time.Since(t.start)
+	}
+	t.logged = true
+
+	duration := time.Since(t.start)
+
+	// Add event to span with duration and extra attrs
+	allAttrs := append([]attribute.KeyValue{
+		attribute.String("duration", duration.String()),
+	}, attrs...)
+
+	span := trace.SpanFromContext(t.ctx)
+	span.AddEvent(t.name+" completed", trace.WithAttributes(allAttrs...))
+
+	// Log if above threshold
+	if duration >= t.threshold {
+		log := clog.FromContext(t.ctx)
+		log.Infof("%s took %s", t.name, duration)
+	}
+
+	return duration
+}
+
+// Duration returns the elapsed time without stopping the timer.
+func (t *Timer) Duration() time.Duration {
+	return time.Since(t.start)
+}
+
+// Elapsed returns a formatted string of the elapsed time.
+func (t *Timer) Elapsed() string {
+	return time.Since(t.start).String()
+}


### PR DESCRIPTION
## Summary

Add comprehensive observability to melange-server to help identify performance bottlenecks during large-scale builds:

- **New tracing package** (`pkg/service/tracing/`) with OpenTelemetry support
  - Enable via `--enable-tracing` flag
  - `Timer` utility for measuring and logging phase durations
  - Helper functions: `StartSpan`, `AddEvent`, `SetAttributes`, `RecordError`

- **API server instrumentation**
  - Trace `createBuild` with config count, package count, build ID
  - Timing for git config loading, DAG construction, store operations

- **Scheduler instrumentation** (most critical for performance visibility)
  - Per-build tracing with package count and final status
  - Per-package 5-phase timing breakdown:
    1. **Setup** - temp files, config writing
    2. **Backend selection** - pool selection time
    3. **Build initialization** - melange build context creation
    4. **BuildKit execution** - the main build (usually the longest)
    5. **Storage sync** - GCS upload time

- **Backend pool logging**
  - Selection time, load percentage, candidate counts
  - Detailed failure reasons (arch filtered, circuit open, at capacity)

- **Storage logging**
  - File count, total size, duration, throughput (MB/s)
  - Progress tracking during concurrent uploads

### Example Log Output

```
processing build abc123 with 5 packages
building package foo in build abc123
backend selection: selected tcp://buildkit:1234 (load=25.0%) in 1ms (candidates=4, arch_filtered=2, circuit_open=0, at_capacity=1)
building package foo for architecture: x86_64 on backend tcp://buildkit:1234
starting BuildKit execution for package foo
BuildKit execution completed in 45.2s for package foo
storage sync: uploading 3 files (12.50 MB) for job abc123-foo to gs://bucket
storage sync complete: uploaded 3 files (12.50 MB) in 2.3s (5.43 MB/s) for job abc123-foo
package foo phase breakdown: setup=15ms, backend=1ms, init=234ms, buildkit=45.2s, sync=2.3s
package foo completed successfully in 47.8s
```

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test -short ./...` passes
- [ ] Deploy to GKE and verify logs appear with timing breakdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)