### PR TITLE
feat: add detailed build timing breakdown

### DIFF
--- a/pkg/service/tracing/tracing.go
+++ b/pkg/service/tracing/tracing.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.17.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -69,11 +69,9 @@ func Setup(ctx context.Context, cfg Config) (func(context.Context) error, error)
 		return nil, err
 	}
 
-	// Create resource with service info
-	res, err := resource.Merge(
-		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
+	// Create resource with service info (don't merge with Default to avoid schema conflicts)
+	res, err := resource.New(ctx,
+		resource.WithAttributes(
 			semconv.ServiceName(cfg.ServiceName),
 			semconv.ServiceVersion(cfg.ServiceVersion),
 		),


### PR DESCRIPTION
## Summary

Break out the BuildKit execution phase into granular timing metrics to identify performance bottlenecks:

- `apko_layer_generation`: time spent generating base image layers with apko
- `layer_load`: time to load apko layers into BuildKit  
- `graph_solve`: time for BuildKit to solve and execute the build graph
- `buildkit_solve`: total time inside BuildWithLayers

Also fixes OpenTelemetry schema conflict by using `resource.New` instead of `resource.Merge` to avoid conflicting schema URLs between semconv versions.

## Results from GKE Testing

Testing on 20-package builds revealed the following breakdown for a typical package:

| Phase | Duration | % of Total |
|-------|----------|------------|
| apko_layer_generation | ~50s | **51%** |
| layer_load | ~17s | 17% |
| graph_solve | ~30s | 32% |
| **Total** | ~97s | 100% |

**Key finding**: apko layer generation is the primary bottleneck (51% of build time), not the actual BuildKit compilation.

Example log output:
```
apko_layer_generation took 48.248049999s (50 layers)
layer_load took 15.436576468s
graph_solve took 29.182694837s
buildkit_solve took 45.525695449s
```

## Optimization Opportunities Identified

1. **Apko layer caching** - Pre-build and cache common base images
2. **Shared apko environments** - Packages with similar deps could share pre-built layers
3. **Reduce layer count** - 50 layers per package is expensive to generate

## Test plan

- [x] Deployed to GKE and verified timing logs appear
- [x] Confirmed tracing schema conflict is resolved
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)