### PR TITLE
fix: handle llb.Git HEAD ref limitation with shell fallback

### DIFF
--- a/pkg/buildkit/builtin_test.go
+++ b/pkg/buildkit/builtin_test.go
@@ -56,9 +56,10 @@ func TestBuildBuiltinPipeline_GitCheckout(t *testing.T) {
 		errorMsg    string
 	}{
 		{
-			name: "basic git clone",
+			name: "basic git clone with branch",
 			with: map[string]string{
 				"repository": "https://github.com/octocat/Hello-World.git",
+				"branch":     "master",
 			},
 			expectError: false,
 		},
@@ -83,6 +84,7 @@ func TestBuildBuiltinPipeline_GitCheckout(t *testing.T) {
 			name: "git clone with custom destination",
 			with: map[string]string{
 				"repository":  "https://github.com/octocat/Hello-World.git",
+				"branch":      "master",
 				"destination": "my-project",
 			},
 			expectError: false,
@@ -91,6 +93,7 @@ func TestBuildBuiltinPipeline_GitCheckout(t *testing.T) {
 			name: "git clone with depth",
 			with: map[string]string{
 				"repository": "https://github.com/octocat/Hello-World.git",
+				"branch":     "master",
 				"depth":      "1",
 			},
 			expectError: false,
@@ -99,9 +102,18 @@ func TestBuildBuiltinPipeline_GitCheckout(t *testing.T) {
 			name: "git clone with full history",
 			with: map[string]string{
 				"repository": "https://github.com/octocat/Hello-World.git",
+				"branch":     "master",
 				"depth":      "-1",
 			},
 			expectError: false,
+		},
+		{
+			name: "git clone without ref returns fallback error",
+			with: map[string]string{
+				"repository": "https://github.com/octocat/Hello-World.git",
+			},
+			expectError: true,
+			errorMsg:    "requires shell fallback",
 		},
 		{
 			name:        "missing repository",

--- a/pkg/buildkit/e2e_test.go
+++ b/pkg/buildkit/e2e_test.go
@@ -1338,9 +1338,11 @@ func TestE2E_BuiltinGitCheckout(t *testing.T) {
 		Pipeline: []config.Pipeline{
 			{
 				// This uses the built-in pipeline with native LLB operations
+				// Note: branch must be specified for native LLB (llb.Git requires explicit ref)
 				Uses: "git-checkout",
 				With: map[string]string{
 					"repository":  "https://github.com/octocat/Hello-World.git",
+					"branch":      "master",
 					"destination": "hello-world",
 					"depth":       "1",
 				},


### PR DESCRIPTION
## Summary
- Returns `ErrGitCheckoutNoRef` when no branch/tag/commit is specified
- Updates `llb.go` to handle fallback errors and continue to shell implementation for unsupported cases
- Updates unit tests to include branch in test cases and verify the fallback error behavior

Fixes the CI E2E test failure where `llb.Git()` was called with no explicit ref, causing BuildKit to fail with "repository does not contain ref HEAD".

## Test plan
- [x] Unit tests pass: `go test -short ./pkg/buildkit/...`
- [x] `go vet ./...` passes
- [ ] CI E2E tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)