### PR TITLE
fix: increase probe timeouts for high-concurrency builds

### DIFF
--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -77,14 +77,18 @@ spec:
           httpGet:
             path: /healthz
             port: 8080
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /healthz
             port: 8080
           initialDelaySeconds: 5
-          periodSeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
         volumeMounts:
         - name: backends-config
           mountPath: /etc/melange
@@ -117,5 +121,5 @@ metadata:
   name: melange-server
   namespace: melange
   annotations:
-    # Workload Identity annotation - will be set by setup script
-    iam.gke.io/gcp-service-account: ""
+    # Workload Identity annotation
+    iam.gke.io/gcp-service-account: melange-server@dlorenc-chainguard.iam.gserviceaccount.com

--- a/deploy/gke/registry.yaml
+++ b/deploy/gke/registry.yaml
@@ -30,6 +30,17 @@ spec:
       labels:
         app: registry
     spec:
+      # Prefer scheduling on default pool nodes, avoid buildkit pool nodes that have high disk usage
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - default-pool
       containers:
       - name: registry
         image: registry:2
@@ -44,23 +55,27 @@ spec:
           value: "true"
         resources:
           requests:
-            memory: "256Mi"
-            cpu: "100m"
+            memory: "512Mi"
+            cpu: "250m"
           limits:
-            memory: "1Gi"
-            cpu: "500m"
+            memory: "2Gi"
+            cpu: "2"
         livenessProbe:
           httpGet:
             path: /v2/
             port: 5000
-          initialDelaySeconds: 5
-          periodSeconds: 10
+          initialDelaySeconds: 10
+          periodSeconds: 30
+          timeoutSeconds: 30
+          failureThreshold: 5
         readinessProbe:
           httpGet:
             path: /v2/
             port: 5000
           initialDelaySeconds: 5
           periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
       volumes:
       - name: registry-data
         emptyDir:


### PR DESCRIPTION
## Summary
- Increase liveness/readiness probe timeouts from 1s to 30s for registry and melange-server
- Increase probe failure thresholds from 3 to 5 (150s total before pod kill)
- Increase registry resource limits (2 CPU, 2Gi memory) to handle concurrent image pushes
- Add node affinity to prefer scheduling registry on default-pool nodes
- Fix workload identity annotation for GCS storage access

## Problem
When running 50+ concurrent package builds, pods were being killed by aggressive liveness probes:
1. **Registry crash**: Default 1s probe timeout was too short when handling concurrent image pushes from 8 BuildKit backends
2. **Server crash**: Melange-server was overwhelmed coordinating parallel builds and failed health checks
3. **GCS permission denied**: Workload identity annotation was empty, causing storage upload failures

## Test Plan
- [x] Tested with 50 package build from wolfi-dev/os
- [x] Achieved 80% success rate (40/50 packages)
- [x] Remaining failures are actual build issues (missing deps, private repos), not infrastructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)