### PR TITLE
docs: document convention-based defaults

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -414,6 +414,34 @@ make gke-port-forward
 make gke-stop-port-forward
 ```
 
+## Convention-Based Defaults
+
+melange2 uses convention over configuration for common paths. These are automatically detected and used:
+
+| Convention | Location | Description |
+|------------|----------|-------------|
+| Pipeline directory | `./pipelines/` | Custom pipelines are automatically loaded |
+| Source directory | `./$pkgname/` | Source files are loaded from a directory named after the package |
+| Signing key | `melange.rsa` or `local-signing.rsa` | First matching key is used for signing |
+
+**Example directory structure:**
+```
+myproject/
+├── curl.yaml              # Package config
+├── curl/                  # Source files for curl package (auto-detected)
+│   ├── patches/
+│   │   └── fix.patch
+│   └── config.ini
+├── pipelines/             # Custom pipelines (auto-detected)
+│   └── custom-build.yaml
+└── melange.rsa            # Signing key (auto-detected)
+```
+
+With this structure, running `./melange2 build curl.yaml` or `./melange2 remote submit curl.yaml` will automatically:
+- Include pipelines from `./pipelines/`
+- Include source files from `./curl/`
+- Use `melange.rsa` for signing (local builds only)
+
 ## Remote Build Commands
 
 The `melange remote` subcommand allows submitting builds to a remote melange-server.
@@ -422,6 +450,7 @@ The `melange remote` subcommand allows submitting builds to a remote melange-ser
 
 ```bash
 # Submit a single package and wait for completion
+# (automatically includes ./pipelines/ and ./$pkgname/ source files)
 ./melange2 remote submit pkg.yaml --server http://localhost:8080 --wait
 
 # Submit with specific architecture
@@ -429,9 +458,6 @@ The `melange remote` subcommand allows submitting builds to a remote melange-ser
 
 # Submit multiple packages (builds in dependency order)
 ./melange2 remote submit lib-a.yaml lib-b.yaml app.yaml --server http://localhost:8080 --wait
-
-# Submit with custom pipelines directory
-./melange2 remote submit pkg.yaml --server http://localhost:8080 --pipeline-dir ./pipelines/ --wait
 
 # Submit from a git repository
 ./melange2 remote submit --git-repo https://github.com/wolfi-dev/os --git-pattern "*.yaml" --server http://localhost:8080
@@ -487,9 +513,10 @@ The `melange remote` subcommand allows submitting builds to a remote melange-ser
 | `--arch` | Target architecture (e.g., x86_64, aarch64) |
 | `--wait` | Wait for job/build to complete before returning |
 | `--debug` | Enable debug logging |
-| `--pipeline-dir` | Directory containing pipeline YAML files |
 | `--backend-selector` | Label selector for backend (key=value) |
 | `--test` | Run tests after build |
+
+Note: Pipelines and source files are automatically included by convention (see [Convention-Based Defaults](#convention-based-defaults)).
 
 ## Dependencies
 

--- a/docs/remote-builds/submitting-builds.md
+++ b/docs/remote-builds/submitting-builds.md
@@ -11,6 +11,7 @@ This guide covers how to submit builds to a melange-server using the CLI.
 
 ```bash
 # Submit a single package and wait for completion
+# (automatically includes ./pipelines/ and ./mypackage/ source files if they exist)
 ./melange2 remote submit mypackage.yaml --server http://localhost:8080 --wait
 
 # Check status of a build
@@ -39,17 +40,18 @@ melange2 remote submit [config.yaml...] [flags]
 | `--test` | bool | `false` | Run tests after build |
 | `--debug` | bool | `false` | Enable debug logging |
 | `--wait` | bool | `false` | Wait for build to complete |
-| `--pipeline-dir` | strings | - | Directories containing pipeline YAML files |
 | `--backend-selector` | strings | - | Backend label selector (`key=value`) |
 | `--git-repo` | string | - | Git repository URL for package configs |
 | `--git-ref` | string | - | Git ref (branch/tag/commit) to checkout |
 | `--git-pattern` | string | `*.yaml` | Glob pattern for config files in git repo |
 | `--git-path` | string | - | Subdirectory within git repo to search |
 
+**Convention-based defaults:** Pipelines from `./pipelines/` and source files from `./$pkgname/` are automatically included if they exist.
+
 **Examples:**
 
 ```bash
-# Submit a single package
+# Submit a single package (auto-includes ./pipelines/ and ./mypackage/ if they exist)
 melange2 remote submit mypackage.yaml --server http://localhost:8080
 
 # Submit and wait for completion
@@ -60,9 +62,6 @@ melange2 remote submit mypackage.yaml --arch aarch64
 
 # Submit multiple packages (builds in dependency order)
 melange2 remote submit lib-a.yaml lib-b.yaml app.yaml --wait
-
-# Submit with custom pipelines
-melange2 remote submit mypackage.yaml --pipeline-dir ./pipelines/
 
 # Submit with backend selector
 melange2 remote submit mypackage.yaml --backend-selector tier=high-memory
@@ -388,11 +387,18 @@ echo "Build succeeded!"
 
 ### Using Custom Pipelines
 
+Custom pipelines are automatically included from `./pipelines/` if the directory exists:
+
 ```bash
-# Include local pipelines directory
+# Project structure:
+# myproject/
+# ├── mypackage.yaml
+# └── pipelines/
+#     └── custom-build.yaml
+
+# Pipelines are automatically uploaded
 ./melange2 remote submit \
   --server http://localhost:8080 \
-  --pipeline-dir ./pipelines \
   --wait \
   mypackage.yaml
 ```

--- a/docs/signing/index.md
+++ b/docs/signing/index.md
@@ -38,15 +38,27 @@ melange2 provides several commands for signing:
 
 ## Signing During Builds
 
-You can sign packages automatically during the build process by providing the `--signing-key` flag:
+melange2 automatically detects and uses signing keys from conventional locations. If `melange.rsa` or `local-signing.rsa` exists in the current directory, it will be used automatically:
 
 ```bash
-melange build package.yaml --signing-key melange.rsa --buildkit-addr tcp://localhost:1234
+# Auto-detects melange.rsa or local-signing.rsa if present
+melange build package.yaml --buildkit-addr tcp://localhost:1234
+
+# Or explicitly specify a key
+melange build package.yaml --signing-key /path/to/mykey.rsa --buildkit-addr tcp://localhost:1234
 ```
 
-When a signing key is provided:
+When a signing key is provided (or auto-detected):
 1. Each built package is signed with the specified key
 2. The generated APKINDEX.tar.gz is also signed (if `--generate-index` is enabled, which is the default)
+
+### Key Auto-Detection
+
+melange2 checks for signing keys in this order:
+1. `melange.rsa` in the current directory
+2. `local-signing.rsa` in the current directory
+
+The first matching key is used. Use the `--signing-key` flag to override.
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

Updates documentation to reflect the new convention-over-configuration defaults added in #110.

### Conventions documented:

| Convention | Location | Description |
|------------|----------|-------------|
| Pipeline directory | `./pipelines/` | Custom pipelines are automatically loaded |
| Source directory | `./$pkgname/` | Source files are loaded from a directory named after the package |
| Signing key | `melange.rsa` or `local-signing.rsa` | First matching key is used for signing |

### Files updated:

- **CLAUDE.md**: Added new "Convention-Based Defaults" section with examples
- **docs/cli/build.md**: Updated flag defaults and added convention documentation
- **docs/cli/remote.md**: Removed `--pipeline-dir` flag documentation, added conventions section
- **docs/remote-builds/submitting-builds.md**: Updated examples and flag documentation
- **docs/signing/index.md**: Added key auto-detection documentation

## Test plan

- [x] Documentation builds (no broken links)
- [x] Examples match actual CLI behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)