### PR TITLE
feat: add flat build mode as default for remote builds

### DIFF
--- a/pkg/service/types/types.go
+++ b/pkg/service/types/types.go
@@ -50,6 +50,11 @@ type CreateBuildRequest struct {
 	// This allows including local source directories (e.g., $pkgname/)
 	// that will be available in the build workspace.
 	SourceFiles map[string]map[string]string `json:"source_files,omitempty"`
+
+	// Mode specifies how packages are scheduled for building.
+	// "flat" (default) builds all packages in parallel without dependency ordering.
+	// "dag" builds packages in dependency order.
+	Mode BuildMode `json:"mode,omitempty"`
 }
 
 // CreateBuildResponse is the response body for creating a build.
@@ -57,6 +62,21 @@ type CreateBuildResponse struct {
 	ID       string   `json:"id"`
 	Packages []string `json:"packages"` // Package names in build order
 }
+
+// BuildMode specifies how packages are scheduled for building.
+type BuildMode string
+
+const (
+	// BuildModeFlat builds all packages in parallel without dependency ordering.
+	// This is useful for full rebuilds where all dependencies are already available
+	// in external repositories.
+	BuildModeFlat BuildMode = "flat"
+
+	// BuildModeDAG builds packages in dependency order, waiting for in-graph
+	// dependencies to complete before building dependent packages.
+	// Note: This mode requires incremental APKINDEX support to be fully effective.
+	BuildModeDAG BuildMode = "dag"
+)
 
 // BuildStatus represents the overall status of a build.
 type BuildStatus string
@@ -136,6 +156,11 @@ type BuildSpec struct {
 
 	// Debug enables debug logging.
 	Debug bool `json:"debug,omitempty"`
+
+	// Mode specifies how packages are scheduled for building.
+	// "flat" (default) builds all packages in parallel without dependency ordering.
+	// "dag" builds packages in dependency order.
+	Mode BuildMode `json:"mode,omitempty"`
 }
 
 // GitSource specifies a git repository source for package configs.


### PR DESCRIPTION
## Summary

This PR redesigns the build scheduling in remote builds as requested in #106:
- Changes the default build mode from DAG-based ordering to **flat mode**
- In flat mode, all packages are built in parallel without dependency ordering
- This is suitable for full rebuilds where dependencies are in external repositories
- The DAG mode is preserved for backward compatibility (use `--mode dag`)

### Changes
- Add `BuildMode` type (`flat`/`dag`) to types.go
- Add `mode` field to `CreateBuildRequest` and `BuildSpec`
- Server defaults to flat mode, skipping topological sort
- In flat mode, dependencies are cleared so all packages are immediately buildable
- Add `--mode` flag to `melange remote submit` CLI command
- Update tests to cover both modes

### Usage

```bash
# Flat mode (default) - all packages build in parallel
melange remote submit lib-a.yaml lib-b.yaml app.yaml

# DAG mode - packages build in dependency order
melange remote submit lib-a.yaml lib-b.yaml app.yaml --mode dag
```

## Test plan

- [x] Unit tests pass (`go test -short ./...`)
- [x] Build succeeds (`go build ./...`)
- [x] go vet passes
- [x] Added test cases for both flat and dag modes with cyclic dependencies

Fixes #106 (first part - flat rebuilds)

A follow-up issue will be created for incremental APKINDEX support in DAG mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)