### PR TITLE
feat: scale server resources for 500+ package builds

### DIFF
--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -28,6 +28,9 @@ spec:
         app: melange-server
     spec:
       serviceAccountName: melange-server
+      # Schedule on buildkit-pool nodes which have 60Gi RAM (default-pool only has 13Gi)
+      nodeSelector:
+        cloud.google.com/gke-nodepool: buildkit-pool
       containers:
       - name: melange-server
         # ko:// reference - ko apply will build and push this image
@@ -37,8 +40,8 @@ spec:
         - --backends-config=/etc/melange/backends.yaml
         - --gcs-bucket=$(GCS_BUCKET)
         - --enable-tracing
-        # max-parallel=0 means use pool capacity (8 backends × 16 jobs = 128)
-        - --max-parallel=0
+        # max-parallel=32 means 2 jobs per BuildKit worker (16 workers × 2 = 32)
+        - --max-parallel=32
         env:
         - name: GCS_BUCKET
           valueFrom:
@@ -81,10 +84,10 @@ spec:
           name: http
         resources:
           requests:
-            memory: "4Gi"
+            memory: "8Gi"
             cpu: "1000m"
           limits:
-            memory: "16Gi"
+            memory: "32Gi"
             cpu: "4000m"
         livenessProbe:
           httpGet:


### PR DESCRIPTION
## Summary
- Increase memory limits from 16Gi to 32Gi to handle large builds
- Increase memory requests from 4Gi to 8Gi
- Set max-parallel=32 for controlled concurrency
- Add nodeSelector to schedule on buildkit-pool nodes (60Gi RAM) instead of default-pool (13Gi RAM)

## Context
When running 500+ package builds, the melange-server was getting OOMKilled on the default-pool nodes which only have ~13Gi RAM. Moving to buildkit-pool nodes (60Gi) and increasing limits to 32Gi provides sufficient headroom.

## Test plan
- [x] Manually tested with 500 package build
- Server no longer OOMKills with these settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)