### PR TITLE
fix: add TTL-based disk cache cleanup for APK packages

### DIFF
--- a/deploy/gke/configmap.yaml
+++ b/deploy/gke/configmap.yaml
@@ -40,6 +40,13 @@ data:
   # Scheduler poll interval (increase for thousands of packages)
   poll-interval: "2s"
 
+  # APK disk cache configuration
+  # Directory for caching downloaded APK packages
+  apk-cache-dir: "/var/cache/apk"
+  # TTL for cached APK files (files older than this are evicted)
+  # Set to 30m for aggressive cleanup during bulk builds
+  apk-cache-ttl: "30m"
+
   # BuildKit backends configuration
   # 15 BuildKit workers using StatefulSet DNS names
   # Each worker can handle 16 concurrent jobs (matching 16-core machines)

--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -93,6 +93,17 @@ spec:
             configMapKeyRef:
               name: melange-config
               key: poll-interval
+        # APK cache env vars
+        - name: APK_CACHE_DIR
+          valueFrom:
+            configMapKeyRef:
+              name: melange-config
+              key: apk-cache-dir
+        - name: APK_CACHE_TTL
+          valueFrom:
+            configMapKeyRef:
+              name: melange-config
+              key: apk-cache-ttl
         ports:
         - containerPort: 8080
           name: http

--- a/pkg/build/buildconfig.go
+++ b/pkg/build/buildconfig.go
@@ -248,6 +248,7 @@ type RemoteBuildParams struct {
 	SourceDir    string
 	OutputDir    string
 	CacheDir     string
+	ApkCacheDir  string
 	BackendAddr  string
 	Debug        bool
 	JobID        string
@@ -276,6 +277,7 @@ func NewBuildConfigForRemote(params RemoteBuildParams) *BuildConfig {
 
 	cfg.OutDir = params.OutputDir
 	cfg.CacheDir = params.CacheDir
+	cfg.ApkCacheDir = params.ApkCacheDir
 	cfg.BuildKitAddr = params.BackendAddr
 	cfg.Debug = params.Debug
 	cfg.GenerateIndex = true


### PR DESCRIPTION
## Summary
- Add TTL-based cleanup for APK package cache directory
- Server was being evicted due to ephemeral-storage pressure (82GB) during bulk builds
- Cleanup runs every 10 minutes, removes files older than configured TTL

## Changes
- `pkg/service/scheduler/scheduler.go`: Add `ApkCacheDir`, `ApkCacheTTL` config and `RunCacheCleanup()` method
- `pkg/build/buildconfig.go`: Add `ApkCacheDir` to `RemoteBuildParams`
- `cmd/melange-server/main.go`: Read `APK_CACHE_DIR` and `APK_CACHE_TTL` env vars
- `deploy/gke/configmap.yaml`: Add cache config (30m TTL for aggressive cleanup)
- `deploy/gke/melange-server.yaml`: Wire up new env vars

## Test plan
- [x] Code compiles (`go build ./...`)
- [ ] Deploy to GKE via CI
- [ ] Run 500 package bulk build
- [ ] Verify disk usage stays bounded

🤖 Generated with [Claude Code](https://claude.com/claude-code)