### PR TITLE
fix: use /tmp for APK cache dir (container runs as non-root)

### DIFF
--- a/deploy/gke/configmap.yaml
+++ b/deploy/gke/configmap.yaml
@@ -42,7 +42,8 @@ data:
 
   # APK disk cache configuration
   # Directory for caching downloaded APK packages
-  apk-cache-dir: "/var/cache/apk"
+  # Using /tmp since container runs as non-root
+  apk-cache-dir: "/tmp/apk-cache"
   # TTL for cached APK files (files older than this are evicted)
   # Set to 30m for aggressive cleanup during bulk builds
   apk-cache-ttl: "30m"


### PR DESCRIPTION
## Summary
- Fix permission denied error when creating APK cache directory
- Use `/tmp/apk-cache` instead of `/var/cache/apk` (container runs as non-root)

## Test plan
- [x] Server starts without permission error

🤖 Generated with [Claude Code](https://claude.com/claude-code)