### PR TITLE
refactor: run builds as root to match QEMU runner behavior

### DIFF
--- a/pkg/buildkit/apko_load_test.go
+++ b/pkg/buildkit/apko_load_test.go
@@ -402,8 +402,7 @@ func startBuildKitContainer(t *testing.T, ctx context.Context) *buildKitContaine
 }
 
 // testBaseState returns a base LLB state suitable for integration tests.
-// It sets up the build user in the test image since wolfi-base doesn't
-// include it by default.
+// It sets up the build environment (ensures /tmp exists, etc.).
 func testBaseState() llb.State {
 	return SetupBuildUser(llb.Image(TestBaseImage))
 }

--- a/pkg/buildkit/builder_test.go
+++ b/pkg/buildkit/builder_test.go
@@ -375,7 +375,7 @@ echo "hello" > /home/build/melange-out/test-pkg/result.txt
 		},
 	}
 
-	// Build the LLB graph using test base state (with build user configured)
+	// Build the LLB graph using test base state
 	state := PrepareWorkspace(testBaseState(), "test-pkg")
 	state, err = pipeline.BuildPipelines(state, pipelines)
 	require.NoError(t, err)

--- a/pkg/buildkit/builtin.go
+++ b/pkg/buildkit/builtin.go
@@ -127,12 +127,12 @@ func buildGitCheckout(base llb.State, p *config.Pipeline) (llb.State, error) {
 	//   tar -c . | tar -C "$dest_fullpath" -x --no-same-owner
 	// This ensures existing files in the destination (like user-provided source files)
 	// are preserved, not deleted or overwritten (unless they conflict with git files).
+	// Running as root (matching QEMU runner behavior), so no chown needed.
 	state := base.Run(
 		llb.Args([]string{"/bin/sh", "-c", fmt.Sprintf(`
 mkdir -p %s
 cd /mnt/gitclone && tar -c . | tar -C %s -x --no-same-owner
-chown -R %d:%d %s
-`, destPath, destPath, BuildUserUID, BuildUserGID, destPath)}),
+`, destPath, destPath)}),
 		llb.AddMount("/mnt/gitclone", gitState, llb.Readonly),
 		llb.WithCustomNamef("[git-checkout] clone and copy to %s", destPath),
 	).Root()

--- a/pkg/buildkit/cache.go
+++ b/pkg/buildkit/cache.go
@@ -32,13 +32,11 @@ type CacheMount struct {
 }
 
 // CacheMountOption returns the LLB run option for this cache mount.
-// The cache directory is created with build user ownership (UID/GID 1000)
-// so that pipeline steps running as the build user can write to the cache.
+// Running as root (matching QEMU runner behavior).
 func (c CacheMount) CacheMountOption() llb.RunOption {
-	// Create a scratch state with a directory owned by the build user.
-	// This follows the same pattern as Docker's RUN --mount=type=cache,uid=X,gid=X
+	// Create a scratch state with a directory for the cache.
 	cacheState := llb.Scratch().File(
-		llb.Mkdir("/cache", 0755, llb.WithUIDGID(BuildUserUID, BuildUserGID)),
+		llb.Mkdir("/cache", 0755),
 	)
 	return llb.AddMount(c.Target, cacheState,
 		llb.AsPersistentCacheDir(c.ID, c.Mode),

--- a/pkg/buildkit/llb_test.go
+++ b/pkg/buildkit/llb_test.go
@@ -294,7 +294,7 @@ echo "hello from pipeline" > /home/build/melange-out/test-pkg/output.txt
 		},
 	}
 
-	// Start with test base state (with build user) and prepare workspace
+	// Start with test base state and prepare workspace
 	base := testBaseState()
 	state := PrepareWorkspace(base, "test-pkg")
 


### PR DESCRIPTION
## Summary

- Switch from dedicated build user (UID 1000) to root (UID 0), matching the QEMU runner behavior in baseline melange
- Simplify `SetupBuildUser()` - no longer creates user/group, just ensures /tmp exists
- Remove unnecessary `chown` operations and `WithUIDGID` calls throughout the codebase
- Work directory remains `/home/build` for compatibility

## Background

The original melange has multiple runners (QEMU, Docker, Bubblewrap). This fork was modeled after the Docker runner which uses a build user (UID 1000). However, the QEMU runner uses root for its operations, which is simpler and avoids permission issues.

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test -short ./...` passes
- [x] `go vet ./...` passes
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)