### PR TITLE
fix: reduce buildkit replicas to 14 to match available capacity

### DIFF
--- a/deploy/gke/apko-server.yaml
+++ b/deploy/gke/apko-server.yaml
@@ -24,6 +24,17 @@ spec:
         app: apko-server
     spec:
       serviceAccountName: melange-server
+      # Prefer scheduling on default pool nodes, avoid buildkit pool nodes
+      affinity:
+        nodeAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: cloud.google.com/gke-nodepool
+                operator: In
+                values:
+                - default-pool
       containers:
         - name: apko-server
           image: ko://github.com/dlorenc/melange2/cmd/apko-server

--- a/deploy/gke/buildkit.yaml
+++ b/deploy/gke/buildkit.yaml
@@ -55,10 +55,11 @@ spec:
     targetPort: 1234
     name: buildkit
 ---
-# StatefulSet for 15 BuildKit workers (240 concurrent builds at maxJobs=16)
+# StatefulSet for 14 BuildKit workers (224 concurrent builds at maxJobs=16)
 # Each pod gets a stable hostname and DNS entry for backend pool configuration
 # Scale calculation: 3673 packages × 5 min avg / 120 min = 153 parallel needed
-# 15 workers × 16 jobs = 240 capacity (headroom for dependency ordering)
+# 14 workers × 16 jobs = 224 capacity (headroom for dependency ordering)
+# Note: Using 14 replicas because melange-server reserves 1 buildkit-pool node
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -66,7 +67,7 @@ metadata:
   namespace: melange
 spec:
   serviceName: buildkit-headless
-  replicas: 15
+  replicas: 14
   podManagementPolicy: Parallel  # Start all pods simultaneously
   selector:
     matchLabels:

--- a/deploy/gke/configmap.yaml
+++ b/deploy/gke/configmap.yaml
@@ -141,11 +141,7 @@ data:
         maxJobs: 16
         labels:
           tier: standard
-      - addr: tcp://buildkit-14.buildkit-headless.melange.svc.cluster.local:1234
-        arch: x86_64
-        maxJobs: 16
-        labels:
-          tier: standard
+      # buildkit-14 removed: melange-server reserves 1 buildkit-pool node
     # Pool-wide configuration
     defaultMaxJobs: 16       # Default max concurrent jobs per backend
     failureThreshold: 5      # Consecutive failures before circuit opens (increased for scale)


### PR DESCRIPTION
## Summary

Fixes CI deploy failures caused by buildkit-14 being stuck in Pending state.

**Root cause**: The buildkit-pool has 15 nodes, but melange-server reserves 1 node via `podAntiAffinity` against buildkit pods. This left only 14 nodes available for buildkit, causing the 15th pod to remain pending and timing out CI deploys.

## Changes

- Reduce buildkit StatefulSet replicas from 15 to 14
- Remove buildkit-14 from backends.yaml config  
- Add node affinity to apko-server to prefer default-pool (prevents it from consuming buildkit node capacity)

## Verification

Already applied to the cluster manually - all 14/14 buildkit pods are now Running.

```
$ kubectl get statefulset buildkit -n melange
NAME       READY   AGE
buildkit   14/14   2d8h
```

## Test plan

- [x] Cluster manually fixed and verified
- [ ] CI tests pass
- [ ] Deploy workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)