### PR TITLE
feat: increase max parallelism from 32 to 64

### DIFF
--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -54,8 +54,8 @@ spec:
         - --backends-config=/etc/melange/backends.yaml
         - --gcs-bucket=$(GCS_BUCKET)
         - --enable-tracing
-        # max-parallel=32 means 2 jobs per BuildKit worker (16 workers × 2 = 32)
-        - --max-parallel=32
+        # max-parallel=64 means ~4-5 jobs per BuildKit worker (14 workers × 4.5 ≈ 64)
+        - --max-parallel=64
         env:
         - name: GCS_BUCKET
           valueFrom:


### PR DESCRIPTION
## Summary

Increase `--max-parallel` from 32 to 64 for higher build throughput.

With 14 BuildKit workers, this allows ~4-5 concurrent jobs per worker instead of ~2.

## Test plan

- [ ] CI passes
- [ ] Deploy succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)