### PR TITLE
fix: add git safe.directory to all shell pipeline steps

### DIFF
--- a/pkg/buildkit/llb.go
+++ b/pkg/buildkit/llb.go
@@ -230,7 +230,14 @@ func (b *PipelineBuilder) buildScript(runs, workdir string) string {
 		debugOpt = 'x'
 	}
 
+	// We add git safe.directory configuration to prevent "dubious ownership" errors.
+	// Git refuses to run in directories owned by different users, which can happen
+	// in BuildKit when steps run as different users. By marking common directories
+	// as safe, we allow git commands (and tools like Go that use git for VCS info)
+	// to work correctly. We use '*' to allow all directories since builds may
+	// create git repos in various locations.
 	return fmt.Sprintf(`set -e%c
+git config --global --add safe.directory '*' 2>/dev/null || true
 [ -d '%s' ] || mkdir -p '%s'
 cd '%s'
 %s


### PR DESCRIPTION
## Summary

- Extends the safe.directory fix from PR #155 to ALL shell pipeline steps
- Fixes the remaining ~108 "error obtaining VCS status" failures from Go builds
- Fixes any package whose Makefile or build script calls git commands

## Problem

PR #155 fixed the git-checkout pipeline, but packages still failed because:
1. Their Makefiles call `git` commands (e.g., to get version info)
2. Go builds use `git` for VCS stamping (`go build` queries git for version)

These commands fail with:
```
fatal: detected dubious ownership in repository at '/home/build'
```
or
```
error obtaining VCS status: exit status 128
```

## Solution

Added `git config --global --add safe.directory '*'` to the shell script wrapper in `buildScript()` that runs ALL pipeline steps. This ensures every step can run git commands safely.

Using `'*'` as the pattern allows all directories, which is safe in our controlled build environment.

## Test plan

- [x] `go build ./...` compiles successfully
- [x] `go test -short ./...` passes
- [ ] Re-run bulk builds to verify success rate improves significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)