### PR TITLE
revert: undo safe.directory fixes and add reproducing test

### DIFF
--- a/e2e/build_test.go
+++ b/e2e/build_test.go
@@ -383,3 +383,17 @@ echo "TEST_VAR=$TEST_VAR" > /home/build/melange-out/integration-test/usr/share/e
 	harness.FileContains(t, outDir, "integration-test/usr/share/result.txt", "integration test output")
 	harness.FileContains(t, outDir, "integration-test/usr/share/env.txt", "TEST_VAR=test-value")
 }
+
+// TestBuild_GitCheckout tests the git-checkout builtin pipeline followed by git commands.
+// This test reproduces the "dubious ownership" error seen in GKE builds after
+// switching to run as root (PR #152).
+func TestBuild_GitCheckout(t *testing.T) {
+	c := newBuildTestContext(t)
+	cfg := c.loadConfig("git-checkout.yaml")
+
+	outDir := c.buildConfig(cfg)
+
+	// If we get here without error, the git commands succeeded
+	harness.FileExists(t, outDir, "git-checkout-test/usr/share/git-checkout-test/git-info.txt")
+	harness.FileContains(t, outDir, "git-checkout-test/usr/share/git-checkout-test/git-info.txt", "commit=")
+}

--- a/e2e/fixtures/build/git-checkout.yaml
+++ b/e2e/fixtures/build/git-checkout.yaml
@@ -1,0 +1,62 @@
+# Git checkout test - validates git-checkout pipeline and subsequent git operations
+#
+# This test reproduces the "dubious ownership" error seen in GKE builds after
+# switching to run as root (PR #152). The issue is:
+# 1. git-checkout clones as root, creating files owned by root
+# 2. Subsequent steps run git commands which fail with "dubious ownership"
+#    because git detects the repo is owned by a different user
+#
+# This test should FAIL until the safe.directory fix is properly implemented.
+package:
+  name: git-checkout-test
+  version: 1.0.0
+
+pipeline:
+  # Step 0: Install git (not in base image)
+  - name: Install git
+    runs: apk add --no-cache git
+
+  # Step 1: Clone a small, public repository using the builtin git-checkout
+  - uses: git-checkout
+    with:
+      repository: https://github.com/wolfi-dev/advisories
+      branch: main
+      destination: advisories
+
+  # Step 1.5: Simulate GKE environment by changing file ownership
+  # In GKE, files from llb.Git() may be owned by a different UID than the build user
+  - name: Simulate ownership mismatch (like GKE)
+    runs: |
+      echo "=== Simulating GKE ownership mismatch ==="
+      echo "Current user: $(whoami) (UID $(id -u))"
+
+      # Create a non-root user to simulate GKE's file ownership
+      adduser -D -u 1000 testuser 2>/dev/null || true
+
+      # Change ownership of git repo to different user (simulates llb.Git behavior in GKE)
+      chown -R 1000:1000 /home/build/advisories
+
+      echo "=== After ownership change ==="
+      ls -la /home/build/advisories/.git/ | head -5
+
+  # Step 2: Run git commands in the cloned directory (as root)
+  # This should trigger "dubious ownership" errors because:
+  # - Files are owned by UID 1000 (testuser)
+  # - Commands run as root (UID 0)
+  # - Git will complain about ownership mismatch
+  - name: Run git commands in cloned repo
+    working-directory: /home/build/advisories
+    runs: |
+      echo "=== Testing git commands as root on non-root-owned repo ==="
+      echo "Current user: $(whoami) (UID $(id -u))"
+
+      # This should fail with "dubious ownership" without safe.directory
+      git status
+      git log --oneline -3
+
+      COMMIT=$(git rev-parse HEAD)
+      echo "HEAD commit: $COMMIT"
+
+      # Save output to prove we got here
+      mkdir -p "${{targets.destdir}}/usr/share/git-checkout-test"
+      echo "commit=$COMMIT" > "${{targets.destdir}}/usr/share/git-checkout-test/git-info.txt"

--- a/pkg/buildkit/builtin.go
+++ b/pkg/buildkit/builtin.go
@@ -128,17 +128,11 @@ func buildGitCheckout(base llb.State, p *config.Pipeline) (llb.State, error) {
 	// This ensures existing files in the destination (like user-provided source files)
 	// are preserved, not deleted or overwritten (unless they conflict with git files).
 	// Running as root (matching QEMU runner behavior), so no chown needed.
-	//
-	// IMPORTANT: We also configure git safe.directory for the destination path.
-	// Git refuses to run in directories owned by different users (dubious ownership).
-	// Since BuildKit may run steps as different users, we need to mark the directory
-	// as safe for git operations. This matches the shell pipeline behavior.
 	state := base.Run(
 		llb.Args([]string{"/bin/sh", "-c", fmt.Sprintf(`
 mkdir -p %s
-git config --global --add safe.directory %s
 cd /mnt/gitclone && tar -c . | tar -C %s -x --no-same-owner
-`, destPath, destPath, destPath)}),
+`, destPath, destPath)}),
 		llb.AddMount("/mnt/gitclone", gitState, llb.Readonly),
 		llb.WithCustomNamef("[git-checkout] clone and copy to %s", destPath),
 	).Root()
@@ -147,17 +141,15 @@ cd /mnt/gitclone && tar -c . | tar -C %s -x --no-same-owner
 	// These require shell commands since BuildKit's Git doesn't support them directly
 	if expectedCommit != "" && branch != "" {
 		// If we have a branch and expected-commit, we may need to reset to the commit
-		// Note: We add safe.directory again here because this step runs as a different user
 		state = state.Run(
 			llb.Args([]string{"/bin/sh", "-c", fmt.Sprintf(`
-git config --global --add safe.directory %s
 cd %s
 current=$(git rev-parse HEAD)
 if [ "$current" != "%s" ]; then
     echo "[git-checkout] resetting to expected commit %s"
     git reset --hard %s
 fi
-`, destPath, destPath, expectedCommit, expectedCommit, expectedCommit)}),
+`, destPath, expectedCommit, expectedCommit, expectedCommit)}),
 			llb.Dir(destPath),
 			llb.User(BuildUserName),
 			llb.WithCustomNamef("[git-checkout] verify commit %s", expectedCommit[:12]),
@@ -168,10 +160,8 @@ fi
 	cherryPicks := with["cherry-picks"]
 	if cherryPicks != "" {
 		// Cherry-picks require running git commands, so we use a shell
-		// Note: We add safe.directory here because this step runs as a different user
 		state = state.Run(
 			llb.Args([]string{"/bin/sh", "-c", fmt.Sprintf(`
-git config --global --add safe.directory %s
 cd %s
 git config user.name "Melange Build"
 git config user.email "melange-build@cgr.dev"
@@ -185,7 +175,7 @@ echo '%s' | while IFS= read -r line; do
     echo "[git-checkout] cherry-picking $hash"
     git cherry-pick -x "$hash" || exit 1
 done
-`, destPath, destPath, cherryPicks)}),
+`, destPath, cherryPicks)}),
 			llb.Dir(destPath),
 			llb.User(BuildUserName),
 			llb.WithCustomName("[git-checkout] apply cherry-picks"),

--- a/pkg/buildkit/llb.go
+++ b/pkg/buildkit/llb.go
@@ -230,14 +230,7 @@ func (b *PipelineBuilder) buildScript(runs, workdir string) string {
 		debugOpt = 'x'
 	}
 
-	// We add git safe.directory configuration to prevent "dubious ownership" errors.
-	// Git refuses to run in directories owned by different users, which can happen
-	// in BuildKit when steps run as different users. By marking common directories
-	// as safe, we allow git commands (and tools like Go that use git for VCS info)
-	// to work correctly. We use '*' to allow all directories since builds may
-	// create git repos in various locations.
 	return fmt.Sprintf(`set -e%c
-git config --global --add safe.directory '*' 2>/dev/null || true
 [ -d '%s' ] || mkdir -p '%s'
 cd '%s'
 %s


### PR DESCRIPTION
## Summary

- Reverts the safe.directory configuration changes from PRs #155 and #156 (they weren't fixing the GKE issue)
- Adds a test that reliably reproduces the "dubious ownership" error locally

## Background

Builds in GKE were failing with ~40% rate due to git "dubious ownership" errors after PR #152 switched to running as root. The attempted fixes in #155 and #156 added `git config --global --add safe.directory` but weren't effective.

## What this PR does

1. **Reverts** the safe.directory additions from builtin.go and llb.go
2. **Adds** a reproducing test (`TestBuild_GitCheckout`) that:
   - Clones a repo using the builtin git-checkout pipeline
   - Changes file ownership to simulate GKE's behavior (files owned by UID 1000)
   - Runs git commands as root on the non-root-owned repo
   - Fails with exit code 128 (dubious ownership)

## Test Plan

- [x] Run `go test -v ./e2e/... -run TestBuild_GitCheckout` - confirms test fails as expected
- [ ] CI should show the test failure
- [ ] This gives us a reliable baseline to iterate on the actual fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)