### PR TITLE
feat: wire up Prometheus metrics in scheduler

### DIFF
--- a/cmd/melange-server/main.go
+++ b/cmd/melange-server/main.go
@@ -284,7 +284,11 @@ func run(ctx context.Context) error {
 		log.Infof("using apko service: %s", apkoService)
 	}
 
-	// Create scheduler
+	// Create scheduler with optional metrics
+	var schedOpts []scheduler.SchedulerOption
+	if melangeMetrics != nil {
+		schedOpts = append(schedOpts, scheduler.WithMetrics(melangeMetrics))
+	}
 	sched := scheduler.New(buildStore, storageBackend, pool, scheduler.Config{
 		OutputDir:            *outputDir,
 		PollInterval:         pollInterval,
@@ -296,7 +300,7 @@ func run(ctx context.Context) error {
 		ApkCacheDir:          apkCacheDir,
 		ApkCacheTTL:          apkCacheTTL,
 		ApkoServiceAddr:      apkoService,
-	})
+	}, schedOpts...)
 
 	// Create output directory (for local storage)
 	if *gcsBucket == "" {

--- a/pkg/service/storage/gcs.go
+++ b/pkg/service/storage/gcs.go
@@ -113,6 +113,11 @@ func (s *GCSStorage) Close() error {
 	return s.client.Close()
 }
 
+// Type returns the storage backend type.
+func (s *GCSStorage) Type() string {
+	return "gcs"
+}
+
 // isRetryableError checks if an error is transient and should be retried.
 func isRetryableError(err error) bool {
 	if err == nil {

--- a/pkg/service/storage/local.go
+++ b/pkg/service/storage/local.go
@@ -37,6 +37,11 @@ func NewLocalStorage(baseDir string) (*LocalStorage, error) {
 	return &LocalStorage{baseDir: baseDir}, nil
 }
 
+// Type returns the storage backend type.
+func (s *LocalStorage) Type() string {
+	return "local"
+}
+
 // WriteLog writes a build log to local storage.
 func (s *LocalStorage) WriteLog(ctx context.Context, jobID, pkgName string, r io.Reader) (string, error) {
 	logDir := filepath.Join(s.baseDir, jobID, "logs")

--- a/pkg/service/storage/storage.go
+++ b/pkg/service/storage/storage.go
@@ -29,6 +29,9 @@ type Artifact struct {
 
 // Storage defines the interface for artifact and log storage.
 type Storage interface {
+	// Type returns the storage backend type (e.g., "local", "gcs").
+	Type() string
+
 	// WriteLog writes a build log and returns its URL.
 	WriteLog(ctx context.Context, jobID, pkgName string, r io.Reader) (url string, err error)
 


### PR DESCRIPTION
## Summary

Connects the existing `MelangeMetrics` to the scheduler to enable observability of build operations. The metrics package already defined comprehensive metrics, but they were never called from the scheduler.

**Changes:**
- Add `WithMetrics()` option to `scheduler.New()` for optional metrics injection
- Record queue depth and backend status on each poll cycle
- Record build started/completed with duration and mode labels
- Record package completed with duration and architecture labels
- Record phase durations (setup, backend_selection, init, buildkit, storage_sync)
- Record storage sync operations by backend type
- Add `Type()` method to `Storage` interface for metric labels

**Metrics now recorded:**

| Metric | Type | Description |
|--------|------|-------------|
| `melange_build_queue_depth` | Gauge | Pending builds waiting |
| `melange_active_builds` | Gauge | Builds currently running |
| `melange_builds_total` | Counter | Total builds by status |
| `melange_build_duration_seconds` | Histogram | Build duration by status/mode |
| `melange_packages_total` | Counter | Packages by status |
| `melange_package_duration_seconds` | Histogram | Package build duration |
| `melange_phase_duration_seconds` | Histogram | Individual phase timings |
| `melange_buildkit_backends_*` | Gauges | Backend pool status |
| `melange_storage_sync_duration_seconds` | Histogram | Storage sync timing |

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes  
- [x] `go test -short ./pkg/service/...` passes
- [x] Metrics are optional (nil-safe checks throughout)

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)