### PR TITLE
refactor: use typed errors instead of string matching

### DIFF
--- a/pkg/service/errors/errors.go
+++ b/pkg/service/errors/errors.go
@@ -1,0 +1,42 @@
+// Copyright 2024 Chainguard, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package errors provides typed errors for the melange service.
+package errors
+
+import "errors"
+
+// Backend pool errors.
+var (
+	// ErrNoAvailableBackend is returned when all backends are at capacity or circuit-open.
+	ErrNoAvailableBackend = errors.New("no available backend: all backends are at capacity or circuit-open")
+
+	// ErrBackendAtCapacity is returned when a backend has reached its maximum job count.
+	ErrBackendAtCapacity = errors.New("backend is at capacity")
+
+	// ErrBackendNotFound is returned when a backend does not exist in the pool.
+	ErrBackendNotFound = errors.New("backend not found")
+
+	// ErrBackendAlreadyExists is returned when adding a backend that already exists.
+	ErrBackendAlreadyExists = errors.New("backend already exists")
+)
+
+// Build store errors.
+var (
+	// ErrBuildNotFound is returned when a build does not exist.
+	ErrBuildNotFound = errors.New("build not found")
+
+	// ErrPackageNotFound is returned when a package job does not exist.
+	ErrPackageNotFound = errors.New("package not found")
+)

--- a/pkg/service/store/memory.go
+++ b/pkg/service/store/memory.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/dlorenc/melange2/pkg/service/dag"
+	svcerrors "github.com/dlorenc/melange2/pkg/service/errors"
 	"github.com/dlorenc/melange2/pkg/service/types"
 	"github.com/google/uuid"
 )
@@ -246,7 +247,7 @@ func (s *MemoryBuildStore) GetBuild(ctx context.Context, id string) (*types.Buil
 
 	build, ok := s.builds[id]
 	if !ok {
-		return nil, fmt.Errorf("build not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, id)
 	}
 
 	// Return a deep copy
@@ -259,7 +260,7 @@ func (s *MemoryBuildStore) UpdateBuild(ctx context.Context, build *types.Build) 
 	defer s.mu.Unlock()
 
 	if _, ok := s.builds[build.ID]; !ok {
-		return fmt.Errorf("build not found: %s", build.ID)
+		return fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, build.ID)
 	}
 
 	s.builds[build.ID] = s.copyBuild(build)
@@ -320,7 +321,7 @@ func (s *MemoryBuildStore) ClaimReadyPackage(ctx context.Context, buildID string
 
 	build, ok := s.builds[buildID]
 	if !ok {
-		return nil, fmt.Errorf("build not found: %s", buildID)
+		return nil, fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, buildID)
 	}
 
 	// Build a set of package names in this build
@@ -377,7 +378,7 @@ func (s *MemoryBuildStore) UpdatePackageJob(ctx context.Context, buildID string,
 
 	build, ok := s.builds[buildID]
 	if !ok {
-		return fmt.Errorf("build not found: %s", buildID)
+		return fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, buildID)
 	}
 
 	// Find and update the package
@@ -388,7 +389,7 @@ func (s *MemoryBuildStore) UpdatePackageJob(ctx context.Context, buildID string,
 		}
 	}
 
-	return fmt.Errorf("package not found: %s", pkg.Name)
+	return fmt.Errorf("%w: %s", svcerrors.ErrPackageNotFound, pkg.Name)
 }
 
 // copyBuild creates a deep copy of a build.

--- a/pkg/service/store/postgres.go
+++ b/pkg/service/store/postgres.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/dlorenc/melange2/pkg/service/dag"
+	svcerrors "github.com/dlorenc/melange2/pkg/service/errors"
 	"github.com/dlorenc/melange2/pkg/service/types"
 	"github.com/google/uuid"
 )
@@ -226,7 +227,7 @@ func (s *PostgresBuildStore) GetBuild(ctx context.Context, id string) (*types.Bu
 		&build.StartedAt, &build.FinishedAt, &specJSON,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
-		return nil, fmt.Errorf("build not found: %s", id)
+		return nil, fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, id)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("querying build: %w", err)
@@ -276,7 +277,7 @@ func (s *PostgresBuildStore) UpdateBuild(ctx context.Context, build *types.Build
 		return fmt.Errorf("updating build: %w", err)
 	}
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("build not found: %s", build.ID)
+		return fmt.Errorf("%w: %s", svcerrors.ErrBuildNotFound, build.ID)
 	}
 	return nil
 }
@@ -559,7 +560,7 @@ func (s *PostgresBuildStore) UpdatePackageJob(ctx context.Context, buildID strin
 		return fmt.Errorf("updating package job: %w", err)
 	}
 	if result.RowsAffected() == 0 {
-		return fmt.Errorf("package not found: %s", pkg.Name)
+		return fmt.Errorf("%w: %s", svcerrors.ErrPackageNotFound, pkg.Name)
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- Add `pkg/service/errors` package with typed errors for pool and store operations
- Update pool.go, memory.go, postgres.go to return wrapped typed errors
- Update api/server.go to use `errors.Is()` instead of `strings.Contains()`

This provides compile-time safety and makes error handling more robust. Error messages remain the same but now include the original error context.

## Changes

| File | Changes |
|------|---------|
| `pkg/service/errors/errors.go` | New package with typed errors |
| `pkg/service/buildkit/pool.go` | Return typed errors from Add/Remove |
| `pkg/service/store/memory.go` | Wrap typed errors in GetBuild/UpdateBuild/etc |
| `pkg/service/store/postgres.go` | Wrap typed errors in GetBuild/UpdateBuild/etc |
| `pkg/service/api/server.go` | Use `errors.Is()` for HTTP status mapping |

## Error Types Added

**Pool errors:**
- `ErrNoAvailableBackend` - all backends at capacity or circuit-open
- `ErrBackendAtCapacity` - backend at maximum jobs
- `ErrBackendNotFound` - backend not in pool
- `ErrBackendAlreadyExists` - duplicate backend

**Store errors:**
- `ErrBuildNotFound` - build ID doesn't exist
- `ErrPackageNotFound` - package name not in build

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short ./pkg/service/...` passes
- [x] `go vet ./pkg/service/...` passes

Fixes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)