### PR TITLE
feat: add environment variable injection for remote builds

### DIFF
--- a/deploy/gke/melange-server.yaml
+++ b/deploy/gke/melange-server.yaml
@@ -104,6 +104,17 @@ spec:
               name: postgres-credentials
               key: dsn
               optional: true
+        # Server-side secrets injected into all builds (from K8s secret)
+        # These take precedence over client --env flags and are NOT logged in requests.
+        # To use: create a secret with your tokens, then reference them here.
+        # Example: kubectl create secret generic build-secrets -n melange \
+        #   --from-literal=GITHUB_TOKEN="$(gh auth token)"
+        - name: SECRET_ENV_GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: build-secrets
+              key: GITHUB_TOKEN
+              optional: true
         ports:
         - containerPort: 8080
           name: http

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -151,6 +151,10 @@ type Build struct {
 	// BuildKitSummary stores detailed step timing from the BuildKit solve.
 	// Populated after BuildPackage completes.
 	BuildKitSummary *buildkit.Summary
+
+	// ExtraEnv contains additional environment variables to inject into all pipeline steps.
+	// This is useful for passing credentials like GITHUB_TOKEN for private repo access.
+	ExtraEnv map[string]string
 }
 
 // NewFromConfig creates a new Build from a BuildConfig.
@@ -203,6 +207,7 @@ func NewFromConfig(ctx context.Context, cfg *BuildConfig) (*Build, error) {
 		ExportOnFailure:            cfg.ExportOnFailure,
 		ExportRef:                  cfg.ExportRef,
 		GenerateProvenance:         cfg.GenerateProvenance,
+		ExtraEnv:                   cfg.ExtraEnv,
 		Start:                      time.Now(),
 		SBOMGenerator:              &spdx.Generator{},
 	}

--- a/pkg/build/build_buildkit.go
+++ b/pkg/build/build_buildkit.go
@@ -156,6 +156,8 @@ func (b *Build) buildPackageBuildKit(ctx context.Context) error {
 		"SOURCE_DATE_EPOCH": fmt.Sprintf("%d", sourceEpoch),
 	}
 	maps.Copy(baseEnv, b.Configuration.Environment.Environment)
+	// Merge in extra environment variables (e.g., GITHUB_TOKEN for private repos)
+	maps.Copy(baseEnv, b.ExtraEnv)
 
 	// Run the build
 	cfg := &buildkit.BuildConfig{

--- a/pkg/build/buildconfig.go
+++ b/pkg/build/buildconfig.go
@@ -172,6 +172,10 @@ type BuildConfig struct {
 
 	// GenerateProvenance indicates whether to generate SLSA provenance.
 	GenerateProvenance bool
+
+	// ExtraEnv contains additional environment variables to inject into all pipeline steps.
+	// This is useful for passing credentials like GITHUB_TOKEN for private repo access.
+	ExtraEnv map[string]string
 }
 
 // NewBuildConfig creates a new BuildConfig with sensible defaults.
@@ -262,6 +266,8 @@ type RemoteBuildParams struct {
 	ApkoRegistry  string
 	ApkoRegistryInsecure bool
 	ApkoServiceAddr string
+	// ExtraEnv contains additional environment variables to inject into all pipeline steps.
+	ExtraEnv map[string]string
 }
 
 // NewBuildConfigForRemote creates a BuildConfig for remote/service builds.
@@ -304,6 +310,9 @@ func NewBuildConfigForRemote(params RemoteBuildParams) *BuildConfig {
 	// Enable default linting for remote builds
 	cfg.LintRequire = linter.DefaultRequiredLinters()
 	cfg.LintWarn = linter.DefaultWarnLinters()
+
+	// Extra environment variables for pipeline steps
+	cfg.ExtraEnv = params.ExtraEnv
 
 	return cfg
 }

--- a/pkg/service/api/server.go
+++ b/pkg/service/api/server.go
@@ -531,6 +531,7 @@ func (s *Server) createBuild(w http.ResponseWriter, r *http.Request) {
 		WithTest:        req.WithTest,
 		Debug:           req.Debug,
 		Mode:            mode,
+		Env:             req.Env,
 	}
 
 	// Create build in store

--- a/pkg/service/types/types.go
+++ b/pkg/service/types/types.go
@@ -55,6 +55,10 @@ type CreateBuildRequest struct {
 	// "flat" (default) builds all packages in parallel without dependency ordering.
 	// "dag" builds packages in dependency order.
 	Mode BuildMode `json:"mode,omitempty"`
+
+	// Env specifies additional environment variables to inject into all pipeline steps.
+	// This is useful for passing credentials like GITHUB_TOKEN for private repo access.
+	Env map[string]string `json:"env,omitempty"`
 }
 
 // CreateBuildResponse is the response body for creating a build.
@@ -200,6 +204,10 @@ type BuildSpec struct {
 	// "flat" (default) builds all packages in parallel without dependency ordering.
 	// "dag" builds packages in dependency order.
 	Mode BuildMode `json:"mode,omitempty"`
+
+	// Env specifies additional environment variables to inject into all pipeline steps.
+	// This is useful for passing credentials like GITHUB_TOKEN for private repo access.
+	Env map[string]string `json:"env,omitempty"`
 }
 
 // GitSource specifies a git repository source for package configs.


### PR DESCRIPTION
## Summary

Add two mechanisms for injecting environment variables into remote builds:

### 1. Client-side `--env` flag (for non-sensitive values only)

```bash
# Non-sensitive environment variables only
./melange2 remote submit pkg.yaml --env BUILD_TYPE=release
```

⚠️ **WARNING**: Values are logged in API requests, so NOT suitable for secrets.

### 2. Server-side `SECRET_ENV_*` injection (for secrets like GITHUB_TOKEN)

```bash
# One-time setup
kubectl create secret generic build-secrets -n melange \
  --from-literal=GITHUB_TOKEN="$(gh auth token)"
```

- Server reads `SECRET_ENV_*` env vars at startup (from K8s secrets)
- Injected into all builds with prefix stripped
- NOT logged in API requests
- Takes precedence over client `--env` flags (security measure)

### Security Design

| Feature | Use For | Logged? | Precedence |
|---------|---------|---------|------------|
| `--env` flag | Non-sensitive config | Yes (API requests) | Lower |
| `SECRET_ENV_*` | Tokens, passwords | No | Higher (wins) |

This enables builds that use the `os/pipelines/auth/github.yaml` pipeline to authenticate with GitHub for private repository access.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -short ./...` passes
- [ ] CI passes
- [ ] Manual test with GKE deployment

## Files changed

- `pkg/service/types/types.go` - Added `Env` field to request/spec types
- `pkg/cli/remote.go` - Added `--env` flag with security warning
- `pkg/build/buildconfig.go` - Added `ExtraEnv` to build params
- `pkg/build/build.go` - Added `ExtraEnv` to Build struct
- `pkg/build/build_buildkit.go` - Merged ExtraEnv into pipeline base env
- `pkg/service/api/server.go` - Passed Env through to BuildSpec
- `pkg/service/scheduler/scheduler.go` - Added SecretEnv config, merging logic
- `cmd/melange-server/main.go` - Added `loadSecretEnv()` function
- `deploy/gke/melange-server.yaml` - Added example secret reference
- `CLAUDE.md` - Documented both features

🤖 Generated with [Claude Code](https://claude.com/claude-code)