### PR TITLE
fix: trim whitespace from SECRET_ENV values

### DIFF
--- a/cmd/melange-server/main.go
+++ b/cmd/melange-server/main.go
@@ -455,7 +455,7 @@ func loadSecretEnv() map[string]string {
 			continue
 		}
 		key := strings.TrimPrefix(parts[0], prefix)
-		value := parts[1]
+		value := strings.TrimSpace(parts[1])
 		if key != "" && value != "" {
 			result[key] = value
 		}


### PR DESCRIPTION
## Summary
- Fixes git authentication failures when GITHUB_TOKEN or other secrets have trailing newlines
- Kubernetes secrets created via `kubectl create secret` often include trailing newlines
- The `loadSecretEnv()` function now trims whitespace from values before injecting into builds

## Root Cause
The `loadSecretEnv()` function was reading secret values directly without trimming whitespace. When secrets are created from files or via kubectl, they often contain trailing newlines (e.g., `ghp_xxx\n`). This caused git authentication to fail with:
```
fatal: could not read Username for 'https://github.com': No such device or address
```

## Test Plan
- [x] Verified secret had trailing newline via `kubectl get secret ... | base64 -d | xxd`
- [x] Deployed fix to GKE cluster
- [x] Confirmed `contour-1.33` (previously failing) now builds successfully
- [x] Server logs now show: `loaded 1 server-side secret env vars: [GITHUB_TOKEN]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)