### PR TITLE
feat: improve GKE deployment reliability with persistent storage

### DIFF
--- a/deploy/gke/apko-server.yaml
+++ b/deploy/gke/apko-server.yaml
@@ -86,10 +86,15 @@ spec:
           volumeMounts:
             - name: apk-cache
               mountPath: /var/cache/apk
+            - name: tmp-storage
+              mountPath: /tmp
       volumes:
         - name: apk-cache
           emptyDir:
-            sizeLimit: 50Gi
+            sizeLimit: 20Gi
+        - name: tmp-storage
+          emptyDir:
+            sizeLimit: 20Gi
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/gke/buildkit.yaml
+++ b/deploy/gke/buildkit.yaml
@@ -131,7 +131,7 @@ spec:
       volumes:
       - name: buildkit-data
         emptyDir:
-          sizeLimit: 50Gi  # Prevent filling node disk; pod evicted if exceeded
+          sizeLimit: 200Gi  # Prevent filling node disk; pod evicted if exceeded
       - name: buildkit-config
         configMap:
           name: buildkit-config

--- a/deploy/gke/registry.yaml
+++ b/deploy/gke/registry.yaml
@@ -12,9 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# PersistentVolumeClaim for registry storage (200Gi SSD)
+# Using PVC instead of emptyDir to avoid node ephemeral storage pressure
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: registry-data
+  namespace: melange
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: premium-rwo  # GKE SSD storage class
+  resources:
+    requests:
+      storage: 200Gi
+---
 # In-cluster container registry for BuildKit cache storage.
 # This provides fast, local cache storage for BuildKit's cache-to/cache-from.
-# Data is ephemeral (emptyDir) - cache loss is acceptable, it rebuilds quickly.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -22,6 +36,8 @@ metadata:
   namespace: melange
 spec:
   replicas: 1
+  strategy:
+    type: Recreate  # Required for RWO PVC
   selector:
     matchLabels:
       app: registry
@@ -53,8 +69,8 @@ spec:
           value: "200"
         resources:
           requests:
-            memory: "4Gi"
-            cpu: "2000m"
+            memory: "2Gi"
+            cpu: "500m"
           limits:
             memory: "8Gi"
             cpu: "4000m"
@@ -76,8 +92,8 @@ spec:
           failureThreshold: 3
       volumes:
       - name: registry-data
-        emptyDir:
-          sizeLimit: 50Gi
+        persistentVolumeClaim:
+          claimName: registry-data
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Summary

- **registry**: Switch from emptyDir to 200Gi PVC for cache persistence across pod restarts, add Recreate strategy for RWO compatibility, reduce resource requests
- **buildkit**: Increase data volume from 50Gi to 200Gi for larger builds
- **apko-server**: Add dedicated /tmp volume (20Gi), reduce apk-cache to 20Gi

## Test plan

- [ ] CI passes
- [ ] Deploy workflow succeeds after merge
- [ ] Verify registry PVC is created: `kubectl get pvc -n melange`
- [ ] Verify pods are healthy: `kubectl get pods -n melange`

🤖 Generated with [Claude Code](https://claude.com/claude-code)