### PR TITLE
feat: maintain process state between test pipeline steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -363,7 +363,7 @@ gke-port-forward: gke-credentials ## Start port forwarding to melange-server (ru
 	@echo "==> Starting port forward to melange-server on port $(GKE_PORT)..."
 	@pkill -f "kubectl port-forward.*melange-server" 2>/dev/null || true
 	@sleep 1
-	@kubectl port-forward -n melange svc/melange-server $(GKE_PORT):8080 &
+	@kubectl port-forward -n melange svc/melange-server $(GKE_PORT):8080 >/dev/null 2>&1 &
 	@sleep 2
 	@echo "==> Port forwarding active. Server available at http://localhost:$(GKE_PORT)"
 	@echo "==> Test with: curl http://localhost:$(GKE_PORT)/healthz"

--- a/e2e/fixtures/test/process-state.yaml
+++ b/e2e/fixtures/test/process-state.yaml
@@ -1,0 +1,148 @@
+# Process state persistence test fixture
+# Tests that process state (background jobs, files) is maintained between test steps
+# while environment variables are isolated (don't leak between steps).
+# This matches the behavior of the old QEMU runner.
+package:
+  name: process-state-test
+  version: 1.0.0
+
+pipeline:
+  - runs: |
+      mkdir -p "${{targets.destdir}}/usr/share/process-state-test"
+      echo "main-marker" > "${{targets.destdir}}/usr/share/process-state-test/marker.txt"
+
+test:
+  pipeline:
+    # Step 1: Start a background process and create files
+    - runs: |
+        echo "Step 1: Starting background process and creating marker files"
+
+        # Create a marker file to prove filesystem state persists
+        echo "step1-was-here" > /tmp/step1-marker.txt
+
+        # Start a background process that will be accessible in later steps
+        # This writes to a file periodically to prove it's still running
+        (
+          while true; do
+            echo "$(date +%s)" >> /tmp/background-log.txt
+            sleep 1
+          done
+        ) &
+        BACKGROUND_PID=$!
+        echo "$BACKGROUND_PID" > /tmp/background.pid
+
+        # Wait a moment for the background process to write something
+        sleep 2
+
+        # Set an environment variable (should NOT leak to next step)
+        export STEP1_SECRET="should-not-leak"
+
+        # Verify background process is running
+        if ! kill -0 "$BACKGROUND_PID" 2>/dev/null; then
+          echo "FAIL: Background process not running in step 1"
+          exit 1
+        fi
+
+        echo "Step 1 complete: background PID $BACKGROUND_PID"
+
+    # Step 2: Verify file state persists and background process still runs
+    - runs: |
+        echo "Step 2: Verifying file state and background process"
+
+        # Check that step 1's marker file exists
+        if [ ! -f /tmp/step1-marker.txt ]; then
+          echo "FAIL: Step 1 marker file missing"
+          exit 1
+        fi
+        if [ "$(cat /tmp/step1-marker.txt)" != "step1-was-here" ]; then
+          echo "FAIL: Step 1 marker file has wrong content"
+          exit 1
+        fi
+        echo "OK: Step 1 marker file exists"
+
+        # Verify step 1's environment variable did NOT leak
+        if [ -n "$STEP1_SECRET" ]; then
+          echo "FAIL: STEP1_SECRET leaked from step 1: $STEP1_SECRET"
+          exit 1
+        fi
+        echo "OK: Environment variables properly isolated"
+
+        # Check that background process is still running
+        if [ ! -f /tmp/background.pid ]; then
+          echo "FAIL: Background PID file missing"
+          exit 1
+        fi
+        BACKGROUND_PID=$(cat /tmp/background.pid)
+        if ! kill -0 "$BACKGROUND_PID" 2>/dev/null; then
+          echo "FAIL: Background process $BACKGROUND_PID no longer running in step 2"
+          exit 1
+        fi
+        echo "OK: Background process $BACKGROUND_PID still running"
+
+        # Verify background process has been writing to its log
+        if [ ! -f /tmp/background-log.txt ]; then
+          echo "FAIL: Background log file missing"
+          exit 1
+        fi
+        LOG_LINES=$(wc -l < /tmp/background-log.txt)
+        if [ "$LOG_LINES" -lt 1 ]; then
+          echo "FAIL: Background process hasn't written any log entries"
+          exit 1
+        fi
+        echo "OK: Background process has written $LOG_LINES log entries"
+
+        # Create step 2 marker
+        echo "step2-was-here" > /tmp/step2-marker.txt
+
+        # Set another environment variable (should NOT leak to next step)
+        export STEP2_SECRET="also-should-not-leak"
+
+        echo "Step 2 complete"
+
+    # Step 3: Final verification
+    - runs: |
+        echo "Step 3: Final verification"
+
+        # Verify step 1 and 2 marker files exist
+        if [ ! -f /tmp/step1-marker.txt ]; then
+          echo "FAIL: Step 1 marker file missing in step 3"
+          exit 1
+        fi
+        if [ ! -f /tmp/step2-marker.txt ]; then
+          echo "FAIL: Step 2 marker file missing in step 3"
+          exit 1
+        fi
+        echo "OK: All marker files present"
+
+        # Verify NO environment variables leaked
+        if [ -n "$STEP1_SECRET" ]; then
+          echo "FAIL: STEP1_SECRET leaked to step 3"
+          exit 1
+        fi
+        if [ -n "$STEP2_SECRET" ]; then
+          echo "FAIL: STEP2_SECRET leaked to step 3"
+          exit 1
+        fi
+        echo "OK: Environment variables properly isolated"
+
+        # Check background process is still running
+        BACKGROUND_PID=$(cat /tmp/background.pid)
+        if ! kill -0 "$BACKGROUND_PID" 2>/dev/null; then
+          echo "FAIL: Background process $BACKGROUND_PID not running in step 3"
+          exit 1
+        fi
+        echo "OK: Background process $BACKGROUND_PID still running in step 3"
+
+        # Count how many log entries the background process has written
+        LOG_LINES=$(wc -l < /tmp/background-log.txt)
+        echo "Background process has written $LOG_LINES log entries total"
+        if [ "$LOG_LINES" -lt 3 ]; then
+          echo "FAIL: Expected at least 3 log entries by now"
+          exit 1
+        fi
+        echo "OK: Background process has been running across all steps"
+
+        # Kill the background process for cleanup
+        kill "$BACKGROUND_PID" 2>/dev/null || true
+
+        echo "ALL TESTS PASSED: Process state persists between steps, env vars isolated"

--- a/e2e/test_test.go
+++ b/e2e/test_test.go
@@ -179,3 +179,18 @@ func TestTestPipeline_NoTests(t *testing.T) {
 	// It's ok if the directory doesn't exist - no tests means nothing to export
 	require.True(t, err == nil || os.IsNotExist(err))
 }
+
+func TestTestPipeline_ProcessStatePersistence(t *testing.T) {
+	// This test verifies that process state (background processes, files) is
+	// maintained between test steps, matching the old QEMU runner behavior.
+	// Environment variables should NOT leak between steps.
+	c := newTestPipelineContext(t)
+	cfg := c.loadTestConfig("process-state.yaml")
+
+	outDir, err := c.runTests(cfg)
+	require.NoError(t, err, "test should succeed - process state should persist between steps while env vars are isolated")
+
+	// Verify test results were exported
+	harness.FileExists(t, outDir, "test-results/process-state-test/status.txt")
+	harness.FileContains(t, outDir, "test-results/process-state-test/status.txt", "PASSED")
+}

--- a/pkg/buildkit/builder.go
+++ b/pkg/buildkit/builder.go
@@ -582,8 +582,9 @@ func (b *Builder) runTestPipelinesWithProvider(ctx context.Context, provider Tes
 	}
 	pipelineBuilder.CacheMounts = b.pipeline.CacheMounts
 
-	// Run test pipelines
-	state, err = pipelineBuilder.BuildPipelines(state, pipelines)
+	// Run test pipelines (merged into single LLB Run for process state persistence)
+	// This maintains background processes between steps while isolating env vars
+	state, err = pipelineBuilder.BuildTestPipelines(state, pipelines)
 	if err != nil {
 		return fmt.Errorf("building test pipelines: %w", err)
 	}


### PR DESCRIPTION
## Summary

- Merge all test pipeline steps into a single LLB Run operation to maintain process state (background processes, files) between steps
- Wrap each step in a subshell to prevent environment variables from leaking between steps
- This matches the behavior of the old QEMU runner where tests like `cadvisor.yaml` can start a background service in step 1 and test against it in subsequent steps

## Changes

- Add `BuildTestPipelines()` method in `pkg/buildkit/llb.go` that combines all test steps into a single shell script
- Update `runTestPipelinesWithProvider()` in `pkg/buildkit/builder.go` to use the new method
- Add e2e test fixture (`e2e/fixtures/test/process-state.yaml`) that verifies:
  - Background processes started in step 1 survive to steps 2 and 3
  - Files created in step 1 persist to steps 2 and 3
  - Environment variables do NOT leak between steps
- Minor Makefile fix to suppress port-forward output

## Test plan

- [x] All existing e2e tests pass
- [x] New `TestTestPipeline_ProcessStatePersistence` test passes
- [x] Unit tests pass (`go test -short ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)