### PR TITLE
fix: apko cache image reference and python/import backwards compatibility

### DIFF
--- a/pkg/build/build_buildkit.go
+++ b/pkg/build/build_buildkit.go
@@ -210,6 +210,13 @@ func (b *Build) buildPackageBuildKit(ctx context.Context) error {
 		releaseData = rd
 		log.Infof("apko_layer_generation took %s (%d layers)", apkoDuration, len(layers))
 
+		// Update ApkoRegistryConfig with the actual image reference from apko service.
+		// buildGuestLayers may update b.ApkoRegistry with a content-addressed tag
+		// (e.g., from "registry:5000/apko-cache" to "registry:5000/apko-cache:abc123").
+		if cfg.ApkoRegistryConfig != nil && b.ApkoRegistry != "" {
+			cfg.ApkoRegistryConfig.Registry = b.ApkoRegistry
+		}
+
 		if err := builder.BuildWithLayers(ctx, layers, cfg); err != nil {
 			b.BuildKitSummary = builder.GetLastSummary()
 			return fmt.Errorf("buildkit build failed: %w", err)

--- a/pkg/build/pipelines/python/import.yaml
+++ b/pkg/build/pipelines/python/import.yaml
@@ -17,13 +17,25 @@ inputs:
         import bark # this is like woof
 
       full-line and inline comments are supported via '#'
-    required: true
+    default: ""
+  import:
+    description: |
+      Backwards-compatible alias for 'imports'. If provided, will be converted
+      to an import statement (e.g., "foo" becomes "import foo").
+    default: ""
 
 pipeline:
   - runs: |
       set +x
       PYTHON="${{inputs.python}}"
       IMPORTS="${{inputs.imports}}"
+      IMPORT="${{inputs.import}}"
+
+      # Support backwards-compatible 'import' input (singular)
+      # Convert "foo" to "import foo" for simple module names
+      if [ -z "$IMPORTS" ] && [ -n "$IMPORT" ]; then
+        IMPORTS="import $IMPORT"
+      fi
 
       perform_import() {
         command="$1"


### PR DESCRIPTION
## Summary

Two fixes discovered during 500-package scale testing:

### 1. Fix apko cache image reference not being updated after service call

- The `ApkoRegistryConfig.Registry` was set **before** calling `buildGuestLayers()`
- When using apko service, `buildGuestLayers()` updates `b.ApkoRegistry` with the content-addressed tag (e.g., `registry:5000/apko-cache:abc123`)
- But `cfg` was already created with the old value, causing BuildKit to fail with:
  ```
  failed to load cache key: registry:5000/apko-cache:latest: not found
  ```
- **Fix:** Update `cfg.ApkoRegistryConfig.Registry` after `buildGuestLayers()` returns

### 2. Add backwards-compatible 'import' input to python/import pipeline

- 686+ packages in wolfi-dev/os use `import: foo` (singular)
- Pipeline expected `imports: ...` (plural)  
- This caused config parse errors: `undefined input 'import' to pipeline`
- **Fix:** Add `import` input that converts to `import $IMPORT` statement

## Test Plan

- [x] Tested with 500-package scale test against GKE cluster
- [x] Before fix: 58 failures (many due to these two bugs)
- [x] After fix: Config parse errors resolved, apko cache errors resolved
- [x] Verified packages that previously failed with config errors now build successfully:
  - audit ✅
  - btrfs-progs ✅
  - conda ✅
  - confluent-docker-utils ✅
  - dask-kubernetes ✅
  - flatbuffers ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)