### PR TITLE
feat: deploy BuildKit Manager service (Phase 6)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -131,6 +131,9 @@ jobs:
           # Deploy melange-orchestrator (build processing)
           ko apply -f deploy/gke/melange-orchestrator.yaml
 
+          # Deploy melange-buildkit-manager (Phase 6: BuildKit worker management)
+          ko apply -f deploy/gke/melange-buildkit-manager.yaml
+
           # Deploy melange-apko-manager (Phase 7: apko instance management)
           ko apply -f deploy/gke/melange-apko-manager.yaml
 
@@ -143,6 +146,7 @@ jobs:
           kubectl rollout status deployment/melange-server -n melange --timeout=180s
           kubectl rollout status deployment/melange-api -n melange --timeout=180s
           kubectl rollout status deployment/melange-orchestrator -n melange --timeout=180s
+          kubectl rollout status deployment/melange-buildkit-manager -n melange --timeout=180s
           kubectl rollout status deployment/melange-apko-manager -n melange --timeout=180s
 
       - name: Verify deployment

--- a/deploy/gke/configmap.yaml
+++ b/deploy/gke/configmap.yaml
@@ -53,7 +53,7 @@ data:
   # service instead of directly managing BuildKit workers.
   # Set to "melange-buildkit-manager:9090" to enable microservices mode.
   # Leave empty to use embedded mode (orchestrator manages workers directly).
-  buildkit-manager-addr: ""
+  buildkit-manager-addr: "melange-buildkit-manager:9090"
 
   # Scaling configuration for large builds
   # Max concurrent GCS uploads (default: 200, was 50)


### PR DESCRIPTION
## Summary

This PR enables the BuildKit Manager microservice deployment to complete Phase 6 of the microservices architecture.

### Changes:
- **ConfigMap**: Set `buildkit-manager-addr` to `"melange-buildkit-manager:9090"` (was empty)
- **Deploy workflow**: Add `ko apply -f deploy/gke/melange-buildkit-manager.yaml` step
- **Deploy workflow**: Add rollout status check for `melange-buildkit-manager`

### Prerequisites (already in place):
- BuildKit Manager code: `cmd/melange-buildkit-manager/main.go` ✅
- gRPC server: `pkg/service/buildkit/grpc_server.go` ✅
- gRPC client: `pkg/service/buildkit/grpc_client.go` ✅
- Deployment manifest: `deploy/gke/melange-buildkit-manager.yaml` ✅
- Orchestrator support for `BUILDKIT_MANAGER_ADDR` env var ✅

### Architecture After Deployment

```
┌─────────────────────────────────────────────────────────────────┐
│                     GKE Deployment                               │
├─────────────────────────────────────────────────────────────────┤
│  melange-api              ✅ Running                            │
│  melange-orchestrator     ✅ Running (will use gRPC to manager) │
│  melange-buildkit-manager ✅ NEW - gRPC service for workers     │
│  melange-apko-manager     ✅ Running                            │
│  buildkit (statefulset)   ✅ Running (15 workers)               │
└─────────────────────────────────────────────────────────────────┘
```

### Communication Flow (after deployment):
```
orchestrator ──gRPC──▶ melange-buildkit-manager ──manages──▶ buildkit workers
             ──gRPC──▶ melange-apko-manager     ──manages──▶ apko-server
```

## Test Plan
- [ ] CI passes (builds successfully)
- [ ] Deployment succeeds
- [ ] Check orchestrator logs for "using BuildKit Manager service at"
- [ ] Verify `/api/v1/backends/status` on buildkit-manager returns worker info
- [ ] Run a test build to verify workers are properly acquired/released

Closes Phase 6 in #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)